### PR TITLE
docs: Update Bitbucket token generation info (#343)

### DIFF
--- a/docs/user-guide/add-git-server.md
+++ b/docs/user-guide/add-git-server.md
@@ -100,10 +100,14 @@ For [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords
       </TabItem>
     </Tabs>
 
-3. Create a secret in the namespace where KubeRocketCI is installed (default is `edp`) to store the Git account credentials, including the **id_rsa**, **username**, and **token** fields.
+3. Create a secret in the namespace where KubeRocketCI is installed (default: `edp`) to securely store the Git account credentials, including the **id_rsa**, **username**, and **token** fields:
 
-   :::note
-   For integration with **Bitbucket**, the **token** field should be populated with the App Password.
+   :::warning
+   For integration with **Bitbucket**, the **token** field should be in the format `username:AppPassword`, encoded in base64. You can generate the encoded token using the following command:
+
+   ```bash
+   echo -n "username:AppPassword" | base64
+   ```
    :::
 
     <Tabs
@@ -183,3 +187,4 @@ For more information on setting up a Ingress and Tekton EventListener for custom
 ## Related Articles
 
 * [Add Application](add-application.md)
+* [Manage Git Servers](git-server-overview.md)

--- a/versioned_docs/version-3.10/user-guide/add-git-server.md
+++ b/versioned_docs/version-3.10/user-guide/add-git-server.md
@@ -100,10 +100,14 @@ For [Bitbucket](https://support.atlassian.com/bitbucket-cloud/docs/app-passwords
       </TabItem>
     </Tabs>
 
-3. Create a secret in the namespace where KubeRocketCI is installed (default is `edp`) to store the Git account credentials, including the **id_rsa**, **username**, and **token** fields.
+3. Create a secret in the namespace where KubeRocketCI is installed (default: `edp`) to securely store the Git account credentials, including the **id_rsa**, **username**, and **token** fields:
 
-   :::note
-   For integration with **Bitbucket**, the **token** field should be populated with the App Password.
+   :::warning
+   For integration with **Bitbucket**, the **token** field should be in the format `username:AppPassword`, encoded in base64. You can generate the encoded token using the following command:
+
+   ```bash
+   echo -n "username:AppPassword" | base64
+   ```
    :::
 
     <Tabs
@@ -183,3 +187,4 @@ For more information on setting up a Ingress and Tekton EventListener for custom
 ## Related Articles
 
 * [Add Application](add-application.md)
+* [Manage Git Servers](git-server-overview.md)


### PR DESCRIPTION
## Description

This minor change clarifies the Bitbucket token generation procedure in the [Add Git Server](https://docs.kuberocketci.io/docs/next/user-guide/add-git-server) documentation page.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement
- [x] Documentation update 

## How Has This Been Tested?

The "npm ci && npm start" command works properly.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.