### PR TITLE
docs: Align cluster-addons git url to new approach

### DIFF
--- a/docs/operator-guide/artifacts-management/harbor-integration.md
+++ b/docs/operator-guide/artifacts-management/harbor-integration.md
@@ -257,7 +257,7 @@ To facilitate seamless interaction between KubeRocketCI and a Harbor project, it
 
 As a result, application images built in UI Portal will be stored in Harbor project and will be deployed from the harbor registry.
 
-Harbor projects can be added and retained with a retention policy generated through the script in [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/harbor-ha/hack/harbor).
+Harbor projects can be added and retained with a retention policy generated through the script in [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/harbor-ha/hack/harbor).
 
 ## Related Articles
 

--- a/docs/operator-guide/artifacts-management/nexus-sonatype.md
+++ b/docs/operator-guide/artifacts-management/nexus-sonatype.md
@@ -20,7 +20,7 @@ Before proceeding, ensure that you have the following prerequisites:
 
 To install Nexus in your environment, it's recommended to use the resources provided in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons) repository. This approach involves installing both the Nexus repository manager and the [nexus-operator](https://github.com/epam/edp-nexus-operator). Leveraging the Cluster Add-Ons simplifies the deployment and management process, providing a streamlined method to integrate Nexus into your infrastructure.
 
-1. **Nexus Repository Manager**: First, navigate to the [Nexus section within the KubeRocketCI Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/nexus) repository. Follow the instructions to deploy Nexus, ensuring it's correctly configured to serve as your artifact repository.
+1. **Nexus Repository Manager**: First, navigate to the [Nexus section within the KubeRocketCI Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/nexus) repository. Follow the instructions to deploy Nexus, ensuring it's correctly configured to serve as your artifact repository.
 
 2. **Nexus-Operator**: Then, proceed with the [nexus-operator](https://github.com/epam/edp-nexus-operator) installation. The operator facilitates easier management and automation of Nexus, allowing for seamless updates, configuration changes, and monitoring.
 

--- a/docs/operator-guide/auth/configure-keycloak-oidc-eks.md
+++ b/docs/operator-guide/auth/configure-keycloak-oidc-eks.md
@@ -13,9 +13,9 @@ To follow the instruction, check the following prerequisites:
 1. (Optional) Terraform version 1.5.7
 2. Kubelogin version >= v1.25.1
 3. (Optional) [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied
-4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/external-secrets)
-5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/keycloak)
-6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/keycloak-operator) is deployed
+4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets)
+5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak)
+6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed
 7. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible
 
 :::note
@@ -57,7 +57,7 @@ The initial step involves setting up the Keycloak operator (configure connection
       </TabItem>
 
       <TabItem value="manual">
-        Deactivate the External Secret Operator within the primary [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/values.yaml#L27) chart:
+        Deactivate the External Secret Operator within the primary [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/values.yaml#L27) chart:
 
         ```yaml title="values.yaml"
         # Configure components of the External Secrets Operator (ESO).
@@ -75,7 +75,7 @@ The initial step involves setting up the Keycloak operator (configure connection
       </TabItem>
     </Tabs>
 
-2. Begin by installing the [**kuberocketci-rbac**](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) add-on. This can be accomplished through the use of the add-ons method, as detailed in the [addons approach](../add-ons-overview.md). Utilize the following values in the `values.yaml` file:
+2. Begin by installing the [**kuberocketci-rbac**](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) add-on. This can be accomplished through the use of the add-ons method, as detailed in the [addons approach](../add-ons-overview.md). Utilize the following values in the `values.yaml` file:
 
     ```yaml title="values.yaml"
     keycloakUrl: "https://example.com"
@@ -96,7 +96,7 @@ The initial step involves setting up the Keycloak operator (configure connection
 
 This add-ons facilitates sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including to EKS, Sonar, Nexus, and Portal.
 
-The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
+The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
 
 ## AWS Configuration
 
@@ -213,7 +213,7 @@ As a result, the required access mapping is implemented using the following reso
 
 | Keycloak Group Name  | Kubernetes ClusterRole | Kubernetes ClusterRoleBinding |
 |----------------------|-------------------------|-------------------------------|
-|  [oidc-cluster-admins](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/keycloak-realmgroups-cluster-admins.yaml) | cluster-admin (built-in)           | [cluster-admin](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/clusterrolebinding-admin.yaml)                 |
+|  [oidc-cluster-admins](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/keycloak-realmgroups-cluster-admins.yaml) | cluster-admin (built-in)           | [cluster-admin](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/clusterrolebinding-admin.yaml)                 |
 
 In this configuration, the Keycloak **oidc-cluster-admins** group is mapped to the Kubernetes **cluster-admin** role. This setup grants members of the **oidc-cluster-admins** group the necessary permissions to perform administrator management in the Kubernetes cluster. You can further customize access by associating different Keycloak groups with specific Kubernetes roles.
 

--- a/docs/operator-guide/auth/eks-oidc-integration.md
+++ b/docs/operator-guide/auth/eks-oidc-integration.md
@@ -11,7 +11,7 @@ This page serves as a comprehensive guide on integrating Keycloak with the [edp-
 ## Install Keycloak Operator
 
 :::info
-Alternately, the edp-keycloak-operator can be installed using a GitOps approach via the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) repository. For detailed installation instructions, please refer to the [Install via Add-ons](../add-ons-overview.md) guide.
+Alternately, the edp-keycloak-operator can be installed using a GitOps approach via the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) repository. For detailed installation instructions, please refer to the [Install via Add-ons](../add-ons-overview.md) guide.
 :::
 
 To install the Keycloak operator, follow the steps below:
@@ -32,7 +32,7 @@ To install the Keycloak operator, follow the steps below:
 ## Connect Keycloak Operator to Keycloak
 
 :::info
-It is also possible to install Keycloak resources using the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/eks) repository. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
+It is also possible to install Keycloak resources using the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/eks) repository. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
 :::
 
 The next stage after installing Keycloak is to integrate it with the Keycloak operator. It can be implemented with the following steps:

--- a/docs/operator-guide/auth/keycloak.md
+++ b/docs/operator-guide/auth/keycloak.md
@@ -377,7 +377,7 @@ To create a Keycloak user in the Master realm who can manage other realms, follo
     ![Role mappings](../../assets/operator-guide/keycloak-roles.png "Role mappings")
 
     :::note
-      `openshift-realm` is the realm name used as the `broker` realm, which is utilized for integrating third-party Identity Providers. You can find more information about this integration in the [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) repository of the KubeRocketCI platform.
+      `openshift-realm` is the realm name used as the `broker` realm, which is utilized for integrating third-party Identity Providers. You can find more information about this integration in the [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) repository of the KubeRocketCI platform.
     :::
 
 ## Related Articles

--- a/docs/operator-guide/auth/oauth2-proxy.md
+++ b/docs/operator-guide/auth/oauth2-proxy.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 ## Integration OAuth2-Proxy
 
-To streamline the installation of OAuth2-Proxy in your environment, it is advised to utilize the resources available in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/oauth2-proxy) and their [applications](https://github.com/epam/edp-cluster-add-ons/blob/main/chart/values.yaml#L120).
+To streamline the installation of OAuth2-Proxy in your environment, it is advised to utilize the resources available in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/oauth2-proxy) and their [applications](https://github.com/epam/edp-cluster-add-ons/blob/main/chart/values.yaml#L120).
 
 ## Enable OAuth2-Proxy on Tekton Dashboard
 

--- a/docs/operator-guide/auth/ui-portal-oidc.md
+++ b/docs/operator-guide/auth/ui-portal-oidc.md
@@ -21,7 +21,7 @@ Ensure the following values are set first before starting the Portal OIDC config
 
 To proceed with the Keycloak configuration, perform the following:
 
-1. Add the URL of the Headlamp to the `valid_redirect_uris` variable in [Keycloak](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/keycloak-client.yaml#L17):
+1. Add the URL of the Headlamp to the `valid_redirect_uris` variable in [Keycloak](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/keycloak-client.yaml#L17):
 
     :::note keycloak_openid_client
 

--- a/docs/operator-guide/project-management-and-reporting/reportportal-keycloak.md
+++ b/docs/operator-guide/project-management-and-reporting/reportportal-keycloak.md
@@ -14,7 +14,7 @@ Follow the steps below to integrate the ReportPortal with Keycloak.
 ## Keycloak Configuration
 
 :::info
-The Keycloak configuration can also be applied using Keycloak resources from the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/report-portal/templates/saml) repository.
+The Keycloak configuration can also be applied using Keycloak resources from the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/report-portal/templates/saml) repository.
 To apply the Keycloak configuration, the Keycloak Operator is required. For installation details, refer to the [Install Keycloak Operator](https://docs.kuberocketci.io/docs/next/operator-guide/auth/eks-oidc-integration#install-keycloak-operator) page.
 :::
 

--- a/docs/operator-guide/upgrade/upgrade-edp-3.8.md
+++ b/docs/operator-guide/upgrade/upgrade-edp-3.8.md
@@ -63,7 +63,7 @@ This section provides detailed instructions for upgrading the KubeRocketCI to th
     :::
 
     :::info
-      Beginning from version 3.8.x, KubeRocketCI uses Argo CD application set instead applications to manage deploy environments, please ensure to upgrade your Argo CD instance to v2.10.3 and higher to work with this kind of resource. An example of how to install it is provided in the [edp-cluster-addons](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/argo-cd/values.yaml#L30) repository.
+      Beginning from version 3.8.x, KubeRocketCI uses Argo CD application set instead applications to manage deploy environments, please ensure to upgrade your Argo CD instance to v2.10.3 and higher to work with this kind of resource. An example of how to install it is provided in the [edp-cluster-addons](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/argo-cd/values.yaml#L30) repository.
     :::
 
 5. Familiarize yourself with the updated file structure of the [values.yaml](https://raw.githubusercontent.com/epam/edp-install/v3.8.1/deploy-templates/values.yaml) file and adjust your values.yaml file accordingly:

--- a/docs/operator-guide/upgrade/upgrade-edp-3.9.md
+++ b/docs/operator-guide/upgrade/upgrade-edp-3.9.md
@@ -23,7 +23,7 @@ This section provides detailed instructions for upgrading the KubeRocketCI to ve
       ]}>
 
       <TabItem value="capsule">
-      1. Take look how to install Capsule using [addons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/capsule).
+      1. Take look how to install Capsule using [addons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/capsule).
       2. [Integrate Capsule](https://epam.github.io/edp-install/operator-guide/capsule) with KubeRocketCI.
       3. Update edp-install values file:
 

--- a/versioned_docs/version-3.10/operator-guide/artifacts-management/harbor-integration.md
+++ b/versioned_docs/version-3.10/operator-guide/artifacts-management/harbor-integration.md
@@ -257,7 +257,7 @@ To facilitate seamless interaction between KubeRocketCI and a Harbor project, it
 
 As a result, application images built in UI Portal will be stored in Harbor project and will be deployed from the harbor registry.
 
-Harbor projects can be added and retained with a retention policy generated through the script in [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/harbor-ha/hack/harbor).
+Harbor projects can be added and retained with a retention policy generated through the script in [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/harbor-ha/hack/harbor).
 
 ## Related Articles
 

--- a/versioned_docs/version-3.10/operator-guide/artifacts-management/nexus-sonatype.md
+++ b/versioned_docs/version-3.10/operator-guide/artifacts-management/nexus-sonatype.md
@@ -20,7 +20,7 @@ Before proceeding, ensure that you have the following prerequisites:
 
 To install Nexus in your environment, it's recommended to use the resources provided in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons) repository. This approach involves installing both the Nexus repository manager and the [nexus-operator](https://github.com/epam/edp-nexus-operator). Leveraging the Cluster Add-Ons simplifies the deployment and management process, providing a streamlined method to integrate Nexus into your infrastructure.
 
-1. **Nexus Repository Manager**: First, navigate to the [Nexus section within the KubeRocketCI Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/nexus) repository. Follow the instructions to deploy Nexus, ensuring it's correctly configured to serve as your artifact repository.
+1. **Nexus Repository Manager**: First, navigate to the [Nexus section within the KubeRocketCI Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/nexus) repository. Follow the instructions to deploy Nexus, ensuring it's correctly configured to serve as your artifact repository.
 
 2. **Nexus-Operator**: Then, proceed with the [nexus-operator](https://github.com/epam/edp-nexus-operator) installation. The operator facilitates easier management and automation of Nexus, allowing for seamless updates, configuration changes, and monitoring.
 

--- a/versioned_docs/version-3.10/operator-guide/auth/configure-keycloak-oidc-eks.md
+++ b/versioned_docs/version-3.10/operator-guide/auth/configure-keycloak-oidc-eks.md
@@ -13,9 +13,9 @@ To follow the instruction, check the following prerequisites:
 1. (Optional) Terraform version 1.5.7
 2. Kubelogin version >= v1.25.1
 3. (Optional) [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied
-4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/external-secrets)
-5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/keycloak)
-6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/keycloak-operator) is deployed
+4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets)
+5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak)
+6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed
 7. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible
 
 :::note
@@ -57,7 +57,7 @@ The initial step involves setting up the Keycloak operator (configure connection
       </TabItem>
 
       <TabItem value="manual">
-        Deactivate the External Secret Operator within the primary [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/values.yaml#L27) chart:
+        Deactivate the External Secret Operator within the primary [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/values.yaml#L27) chart:
 
         ```yaml title="values.yaml"
         # Configure components of the External Secrets Operator (ESO).
@@ -75,7 +75,7 @@ The initial step involves setting up the Keycloak operator (configure connection
       </TabItem>
     </Tabs>
 
-2. Begin by installing the [**kuberocketci-rbac**](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) add-on. This can be accomplished through the use of the add-ons method, as detailed in the [addons approach](../add-ons-overview.md). Utilize the following values in the `values.yaml` file:
+2. Begin by installing the [**kuberocketci-rbac**](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) add-on. This can be accomplished through the use of the add-ons method, as detailed in the [addons approach](../add-ons-overview.md). Utilize the following values in the `values.yaml` file:
 
     ```yaml title="values.yaml"
     keycloakUrl: "https://example.com"
@@ -96,7 +96,7 @@ The initial step involves setting up the Keycloak operator (configure connection
 
 This add-ons facilitates sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including to EKS, Sonar, Nexus, and Portal.
 
-The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
+The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
 
 ## AWS Configuration
 
@@ -213,7 +213,7 @@ As a result, the required access mapping is implemented using the following reso
 
 | Keycloak Group Name  | Kubernetes ClusterRole | Kubernetes ClusterRoleBinding |
 |----------------------|-------------------------|-------------------------------|
-|  [oidc-cluster-admins](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/keycloak-realmgroups-cluster-admins.yaml) | cluster-admin (built-in)           | [cluster-admin](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/clusterrolebinding-admin.yaml)                 |
+|  [oidc-cluster-admins](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/keycloak-realmgroups-cluster-admins.yaml) | cluster-admin (built-in)           | [cluster-admin](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/clusterrolebinding-admin.yaml)                 |
 
 In this configuration, the Keycloak **oidc-cluster-admins** group is mapped to the Kubernetes **cluster-admin** role. This setup grants members of the **oidc-cluster-admins** group the necessary permissions to perform administrator management in the Kubernetes cluster. You can further customize access by associating different Keycloak groups with specific Kubernetes roles.
 

--- a/versioned_docs/version-3.10/operator-guide/auth/eks-oidc-integration.md
+++ b/versioned_docs/version-3.10/operator-guide/auth/eks-oidc-integration.md
@@ -11,7 +11,7 @@ This page serves as a comprehensive guide on integrating Keycloak with the [edp-
 ## Install Keycloak Operator
 
 :::info
-Alternately, the edp-keycloak-operator can be installed using a GitOps approach via the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) repository. For detailed installation instructions, please refer to the [Install via Add-ons](../add-ons-overview.md) guide.
+Alternately, the edp-keycloak-operator can be installed using a GitOps approach via the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) repository. For detailed installation instructions, please refer to the [Install via Add-ons](../add-ons-overview.md) guide.
 :::
 
 To install the Keycloak operator, follow the steps below:
@@ -32,7 +32,7 @@ To install the Keycloak operator, follow the steps below:
 ## Connect Keycloak Operator to Keycloak
 
 :::info
-It is also possible to install Keycloak resources using the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/eks) repository. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
+It is also possible to install Keycloak resources using the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/eks) repository. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
 :::
 
 The next stage after installing Keycloak is to integrate it with the Keycloak operator. It can be implemented with the following steps:

--- a/versioned_docs/version-3.10/operator-guide/auth/keycloak.md
+++ b/versioned_docs/version-3.10/operator-guide/auth/keycloak.md
@@ -377,7 +377,7 @@ To create a Keycloak user in the Master realm who can manage other realms, follo
     ![Role mappings](../../assets/operator-guide/keycloak-roles.png "Role mappings")
 
     :::note
-      `openshift-realm` is the realm name used as the `broker` realm, which is utilized for integrating third-party Identity Providers. You can find more information about this integration in the [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) repository of the KubeRocketCI platform.
+      `openshift-realm` is the realm name used as the `broker` realm, which is utilized for integrating third-party Identity Providers. You can find more information about this integration in the [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) repository of the KubeRocketCI platform.
     :::
 
 ## Related Articles

--- a/versioned_docs/version-3.10/operator-guide/auth/oauth2-proxy.md
+++ b/versioned_docs/version-3.10/operator-guide/auth/oauth2-proxy.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 ## Integration OAuth2-Proxy
 
-To streamline the installation of OAuth2-Proxy in your environment, it is advised to utilize the resources available in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/oauth2-proxy) and their [applications](https://github.com/epam/edp-cluster-add-ons/blob/main/chart/values.yaml#L120).
+To streamline the installation of OAuth2-Proxy in your environment, it is advised to utilize the resources available in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/oauth2-proxy) and their [applications](https://github.com/epam/edp-cluster-add-ons/blob/main/chart/values.yaml#L120).
 
 ## Enable OAuth2-Proxy on Tekton Dashboard
 

--- a/versioned_docs/version-3.10/operator-guide/auth/ui-portal-oidc.md
+++ b/versioned_docs/version-3.10/operator-guide/auth/ui-portal-oidc.md
@@ -21,7 +21,7 @@ Ensure the following values are set first before starting the Portal OIDC config
 
 To proceed with the Keycloak configuration, perform the following:
 
-1. Add the URL of the Headlamp to the `valid_redirect_uris` variable in [Keycloak](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/keycloak-client.yaml#L17):
+1. Add the URL of the Headlamp to the `valid_redirect_uris` variable in [Keycloak](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/keycloak-client.yaml#L17):
 
     :::note keycloak_openid_client
 

--- a/versioned_docs/version-3.10/operator-guide/project-management-and-reporting/reportportal-keycloak.md
+++ b/versioned_docs/version-3.10/operator-guide/project-management-and-reporting/reportportal-keycloak.md
@@ -14,7 +14,7 @@ Follow the steps below to integrate the ReportPortal with Keycloak.
 ## Keycloak Configuration
 
 :::info
-The Keycloak configuration can also be applied using Keycloak resources from the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/report-portal/templates/saml) repository.
+The Keycloak configuration can also be applied using Keycloak resources from the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/report-portal/templates/saml) repository.
 To apply the Keycloak configuration, the Keycloak Operator is required. For installation details, refer to the [Install Keycloak Operator](https://docs.kuberocketci.io/docs/next/operator-guide/auth/eks-oidc-integration#install-keycloak-operator) page.
 :::
 

--- a/versioned_docs/version-3.10/operator-guide/upgrade/upgrade-edp-3.8.md
+++ b/versioned_docs/version-3.10/operator-guide/upgrade/upgrade-edp-3.8.md
@@ -63,7 +63,7 @@ This section provides detailed instructions for upgrading the KubeRocketCI to th
     :::
 
     :::info
-      Beginning from version 3.8.x, KubeRocketCI uses Argo CD application set instead applications to manage deploy environments, please ensure to upgrade your Argo CD instance to v2.10.3 and higher to work with this kind of resource. An example of how to install it is provided in the [edp-cluster-addons](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/argo-cd/values.yaml#L30) repository.
+      Beginning from version 3.8.x, KubeRocketCI uses Argo CD application set instead applications to manage deploy environments, please ensure to upgrade your Argo CD instance to v2.10.3 and higher to work with this kind of resource. An example of how to install it is provided in the [edp-cluster-addons](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/argo-cd/values.yaml#L30) repository.
     :::
 
 5. Familiarize yourself with the updated file structure of the [values.yaml](https://raw.githubusercontent.com/epam/edp-install/v3.8.1/deploy-templates/values.yaml) file and adjust your values.yaml file accordingly:

--- a/versioned_docs/version-3.10/operator-guide/upgrade/upgrade-edp-3.9.md
+++ b/versioned_docs/version-3.10/operator-guide/upgrade/upgrade-edp-3.9.md
@@ -23,7 +23,7 @@ This section provides detailed instructions for upgrading the KubeRocketCI to ve
       ]}>
 
       <TabItem value="capsule">
-      1. Take look how to install Capsule using [addons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/capsule).
+      1. Take look how to install Capsule using [addons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/capsule).
       2. [Integrate Capsule](https://epam.github.io/edp-install/operator-guide/capsule) with KubeRocketCI.
       3. Update edp-install values file:
 

--- a/versioned_docs/version-3.9/operator-guide/artifacts-management/harbor-integration.md
+++ b/versioned_docs/version-3.9/operator-guide/artifacts-management/harbor-integration.md
@@ -257,7 +257,7 @@ To facilitate seamless interaction between KubeRocketCI and a Harbor project, it
 
 As a result, application images built in UI Portal will be stored in Harbor project and will be deployed from the harbor registry.
 
-Harbor projects can be added and retained with a retention policy generated through the script in [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/harbor-ha/hack/harbor).
+Harbor projects can be added and retained with a retention policy generated through the script in [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/harbor-ha/hack/harbor).
 
 ## Related Articles
 

--- a/versioned_docs/version-3.9/operator-guide/artifacts-management/nexus-sonatype.md
+++ b/versioned_docs/version-3.9/operator-guide/artifacts-management/nexus-sonatype.md
@@ -20,7 +20,7 @@ Before proceeding, ensure that you have the following prerequisites:
 
 To install Nexus in your environment, it's recommended to use the resources provided in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons) repository. This approach involves installing both the Nexus repository manager and the [nexus-operator](https://github.com/epam/edp-nexus-operator). Leveraging the Cluster Add-Ons simplifies the deployment and management process, providing a streamlined method to integrate Nexus into your infrastructure.
 
-1. **Nexus Repository Manager**: First, navigate to the [Nexus section within the KubeRocketCI Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/nexus) repository. Follow the instructions to deploy Nexus, ensuring it's correctly configured to serve as your artifact repository.
+1. **Nexus Repository Manager**: First, navigate to the [Nexus section within the KubeRocketCI Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/nexus) repository. Follow the instructions to deploy Nexus, ensuring it's correctly configured to serve as your artifact repository.
 
 2. **Nexus-Operator**: Then, proceed with the [nexus-operator](https://github.com/epam/edp-nexus-operator) installation. The operator facilitates easier management and automation of Nexus, allowing for seamless updates, configuration changes, and monitoring.
 

--- a/versioned_docs/version-3.9/operator-guide/auth/configure-keycloak-oidc-eks.md
+++ b/versioned_docs/version-3.9/operator-guide/auth/configure-keycloak-oidc-eks.md
@@ -13,9 +13,9 @@ To follow the instruction, check the following prerequisites:
 1. (Optional) Terraform version 1.5.7
 2. Kubelogin version >= v1.25.1
 3. (Optional) [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied
-4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/external-secrets)
-5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/keycloak)
-6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/keycloak-operator) is deployed
+4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets)
+5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak)
+6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed
 7. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible
 
 :::note
@@ -57,7 +57,7 @@ The initial step involves setting up the Keycloak operator (configure connection
       </TabItem>
 
       <TabItem value="manual">
-        Deactivate the External Secret Operator within the primary [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/values.yaml#L27) chart:
+        Deactivate the External Secret Operator within the primary [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/values.yaml#L27) chart:
 
         ```yaml title="values.yaml"
         # Configure components of the External Secrets Operator (ESO).
@@ -75,7 +75,7 @@ The initial step involves setting up the Keycloak operator (configure connection
       </TabItem>
     </Tabs>
 
-2. Begin by installing the [**kuberocketci-rbac**](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) add-on. This can be accomplished through the use of the add-ons method, as detailed in the [addons approach](../add-ons-overview.md). Utilize the following values in the `values.yaml` file:
+2. Begin by installing the [**kuberocketci-rbac**](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) add-on. This can be accomplished through the use of the add-ons method, as detailed in the [addons approach](../add-ons-overview.md). Utilize the following values in the `values.yaml` file:
 
     ```yaml title="values.yaml"
     keycloakUrl: "https://example.com"
@@ -96,7 +96,7 @@ The initial step involves setting up the Keycloak operator (configure connection
 
 This add-ons facilitates sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including to EKS, Sonar, Nexus, and Portal.
 
-The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
+The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
 
 ## AWS Configuration
 
@@ -213,7 +213,7 @@ As a result, the required access mapping is implemented using the following reso
 
 | Keycloak Group Name  | Kubernetes ClusterRole | Kubernetes ClusterRoleBinding |
 |----------------------|-------------------------|-------------------------------|
-|  [oidc-cluster-admins](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/keycloak-realmgroups-cluster-admins.yaml) | cluster-admin (built-in)           | [cluster-admin](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/clusterrolebinding-admin.yaml)                 |
+|  [oidc-cluster-admins](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/keycloak-realmgroups-cluster-admins.yaml) | cluster-admin (built-in)           | [cluster-admin](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/clusterrolebinding-admin.yaml)                 |
 
 In this configuration, the Keycloak **oidc-cluster-admins** group is mapped to the Kubernetes **cluster-admin** role. This setup grants members of the **oidc-cluster-admins** group the necessary permissions to perform administrator management in the Kubernetes cluster. You can further customize access by associating different Keycloak groups with specific Kubernetes roles.
 

--- a/versioned_docs/version-3.9/operator-guide/auth/eks-oidc-integration.md
+++ b/versioned_docs/version-3.9/operator-guide/auth/eks-oidc-integration.md
@@ -11,7 +11,7 @@ This page serves as a comprehensive guide on integrating Keycloak with the [edp-
 ## Install Keycloak Operator
 
 :::info
-Alternately, the edp-keycloak-operator can be installed using a GitOps approach via the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) repository. For detailed installation instructions, please refer to the [Install via Add-ons](../add-ons-overview.md) guide.
+Alternately, the edp-keycloak-operator can be installed using a GitOps approach via the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) repository. For detailed installation instructions, please refer to the [Install via Add-ons](../add-ons-overview.md) guide.
 :::
 
 To install the Keycloak operator, follow the steps below:
@@ -32,7 +32,7 @@ To install the Keycloak operator, follow the steps below:
 ## Connect Keycloak Operator to Keycloak
 
 :::info
-It is also possible to install Keycloak resources using the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/eks) repository. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
+It is also possible to install Keycloak resources using the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/eks) repository. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
 :::
 
 The next stage after installing Keycloak is to integrate it with the Keycloak operator. It can be implemented with the following steps:

--- a/versioned_docs/version-3.9/operator-guide/auth/keycloak.md
+++ b/versioned_docs/version-3.9/operator-guide/auth/keycloak.md
@@ -377,7 +377,7 @@ To create a Keycloak user in the Master realm who can manage other realms, follo
     ![Role mappings](../../assets/operator-guide/keycloak-roles.png "Role mappings")
 
     :::note
-      `openshift-realm` is the realm name used as the `broker` realm, which is utilized for integrating third-party Identity Providers. You can find more information about this integration in the [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/kuberocketci-rbac) repository of the KubeRocketCI platform.
+      `openshift-realm` is the realm name used as the `broker` realm, which is utilized for integrating third-party Identity Providers. You can find more information about this integration in the [kuberocketci-rbac](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) repository of the KubeRocketCI platform.
     :::
 
 ## Related Articles

--- a/versioned_docs/version-3.9/operator-guide/auth/oauth2-proxy.md
+++ b/versioned_docs/version-3.9/operator-guide/auth/oauth2-proxy.md
@@ -12,7 +12,7 @@ import TabItem from '@theme/TabItem';
 
 ## Integration OAuth2-Proxy
 
-To streamline the installation of OAuth2-Proxy in your environment, it is advised to utilize the resources available in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/oauth2-proxy) and their [applications](https://github.com/epam/edp-cluster-add-ons/blob/main/chart/values.yaml#L120).
+To streamline the installation of OAuth2-Proxy in your environment, it is advised to utilize the resources available in the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/oauth2-proxy) and their [applications](https://github.com/epam/edp-cluster-add-ons/blob/main/chart/values.yaml#L120).
 
 ## Enable OAuth2-Proxy on Tekton Dashboard
 

--- a/versioned_docs/version-3.9/operator-guide/auth/ui-portal-oidc.md
+++ b/versioned_docs/version-3.9/operator-guide/auth/ui-portal-oidc.md
@@ -21,7 +21,7 @@ Ensure the following values are set first before starting the Portal OIDC config
 
 To proceed with the Keycloak configuration, perform the following:
 
-1. Add the URL of the Headlamp to the `valid_redirect_uris` variable in [Keycloak](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/kuberocketci-rbac/templates/kubernetes/keycloak-client.yaml#L17):
+1. Add the URL of the Headlamp to the `valid_redirect_uris` variable in [Keycloak](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/kuberocketci-rbac/templates/kubernetes/keycloak-client.yaml#L17):
 
     :::note keycloak_openid_client
 

--- a/versioned_docs/version-3.9/operator-guide/project-management-and-reporting/reportportal-keycloak.md
+++ b/versioned_docs/version-3.9/operator-guide/project-management-and-reporting/reportportal-keycloak.md
@@ -14,7 +14,7 @@ Follow the steps below to integrate the ReportPortal with Keycloak.
 ## Keycloak Configuration
 
 :::info
-The Keycloak configuration can also be applied using Keycloak resources from the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/report-portal/templates/saml) repository.
+The Keycloak configuration can also be applied using Keycloak resources from the [Cluster Add-Ons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/report-portal/templates/saml) repository.
 To apply the Keycloak configuration, the Keycloak Operator is required. For installation details, refer to the [Install Keycloak Operator](https://docs.kuberocketci.io/docs/next/operator-guide/auth/eks-oidc-integration#install-keycloak-operator) page.
 :::
 

--- a/versioned_docs/version-3.9/operator-guide/upgrade/upgrade-edp-3.8.md
+++ b/versioned_docs/version-3.9/operator-guide/upgrade/upgrade-edp-3.8.md
@@ -63,7 +63,7 @@ This section provides detailed instructions for upgrading the KubeRocketCI to th
     :::
 
     :::info
-      Beginning from version 3.8.x, KubeRocketCI uses Argo CD application set instead applications to manage deploy environments, please ensure to upgrade your Argo CD instance to v2.10.3 and higher to work with this kind of resource. An example of how to install it is provided in the [edp-cluster-addons](https://github.com/epam/edp-cluster-add-ons/blob/main/add-ons/argo-cd/values.yaml#L30) repository.
+      Beginning from version 3.8.x, KubeRocketCI uses Argo CD application set instead applications to manage deploy environments, please ensure to upgrade your Argo CD instance to v2.10.3 and higher to work with this kind of resource. An example of how to install it is provided in the [edp-cluster-addons](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/argo-cd/values.yaml#L30) repository.
     :::
 
 5. Familiarize yourself with the updated file structure of the [values.yaml](https://raw.githubusercontent.com/epam/edp-install/v3.8.1/deploy-templates/values.yaml) file and adjust your values.yaml file accordingly:

--- a/versioned_docs/version-3.9/operator-guide/upgrade/upgrade-edp-3.9.md
+++ b/versioned_docs/version-3.9/operator-guide/upgrade/upgrade-edp-3.9.md
@@ -23,7 +23,7 @@ This section provides detailed instructions for upgrading the KubeRocketCI to ve
       ]}>
 
       <TabItem value="capsule">
-      1. Take look how to install Capsule using [addons](https://github.com/epam/edp-cluster-add-ons/tree/main/add-ons/capsule).
+      1. Take look how to install Capsule using [addons](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/capsule).
       2. [Integrate Capsule](https://epam.github.io/edp-install/operator-guide/capsule) with KubeRocketCI.
       3. Update edp-install values file:
 


### PR DESCRIPTION
## Description

Align application URL for edp-cluster-add-ons after switching to the new approach of installing addons.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement

## How Has This Been Tested?

Checked URL redirection on the local version of the documentation.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.
