### PR TITLE
docs: Add use case preview on overview page

### DIFF
--- a/src/features/use-cases/constants.tsx
+++ b/src/features/use-cases/constants.tsx
@@ -51,4 +51,27 @@ export const useCasesList: UseCaseItem[] = [
     ),
     link: '/docs/use-cases/autotest-as-quality-gate',
   },
+  {
+    title: 'Creating and Using Custom Tekton Pipelines',
+    Svg: BuildIcon,
+    description: (
+      <>
+        How to create and use custom Tekton pipelines. While KubeRocketCI offers pre-configured Tekton pipelines for common
+        use cases, custom pipelines allow you to adapt workflows to meet unique project requirements.
+      </>
+    ),
+    link: '/docs/use-cases/custom-pipelines-flow',
+  },
+  {
+    title: 'Set Test Suite Parameters Using Environment Variables in CD Pipelines',
+    Svg: BuildIcon,
+    description: (
+      <>
+        Dynamically adjust parameters adding, modifying, or removing them without changing the test suite code.
+        This provides precise control over quality gates, streamlines workflows, and allows pipelines to adapt
+        to different environments or requirements while maintaining efficiency and quality standards.
+      </>
+    ),
+    link: '/docs/use-cases/cd-autotests-run-with-env-variables',
+  },
 ];


### PR DESCRIPTION
## Description

Add use case Set Test Suite Parameters Using Environment Variables in CD Pipelines to use case overview page

## Type of change

- [x] Improvement

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.
