### PR TITLE
fix: Add IRSA cross-account deployment guide to 3.10

### DIFF
--- a/versioned_sidebars/version-3.10-sidebars.json
+++ b/versioned_sidebars/version-3.10-sidebars.json
@@ -272,6 +272,7 @@
             "operator-guide/cd/manual-approval",
             "operator-guide/cd/deploy-rpm",
             "operator-guide/cd/auto-stable-trigger-type",
+            "operator-guide/cd/deploy-application-in-remote-cluster-via-irsa",
             {
               "type": "category",
               "label": "GitOps",


### PR DESCRIPTION
## Description

Add new documentation for cross-account deployment using IRSA (IAM Roles for Service Accounts) in KubeRocketCI. The guide provides comprehensive instructions for setting up secure deployments across AWS accounts, including:

- IAM roles and policies configuration for both accounts
- Cluster connection setup
- Service account annotations
- ArgoCD integration
- Deployment flow configuration
- Diagram

Fixes #(issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Followed all steps in a test environment with two AWS accounts
- Verified all IAM roles and policies configurations
- Successfully connected remote cluster using IRSA
- Tested deployment flow with sample application
- Verified ArgoCD integration and cluster status
- Validated all provided commands and configurations


## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.