### PR TITLE
docs: replace EDP versioning with SemVer everywhere

### DIFF
--- a/docs/user-guide/add-application.md
+++ b/docs/user-guide/add-application.md
@@ -125,7 +125,7 @@ In the **Advanced Settings** menu, specify the branch options and define the Jir
 
 * **Codebase versioning type** - defines how will the application tag be changed once the new image version is built. There are two versioning types:
   * **default**: Using the `default` versioning type, in order to specify the version of the current artifacts, images, and tags in the Version Control System, a developer should navigate to the corresponding file and change the version **manually**.
-  * **semver**: Using the `semver` versioning type, a developer indicates the version number from which all the artifacts will be versioned and, as a result, **automatically** registered in the corresponding file (e.g. pom.xml). When selecting the `edp` versioning type, the extra fields will appear, type the version number from which you want the artifacts to be versioned:
+  * **semver**: Using the `semver` versioning type, a developer indicates the version number from which all the artifacts will be versioned and, as a result, **automatically** registered in the corresponding file (e.g. pom.xml). When selecting the `semver` versioning type, the extra fields will appear, type the version number from which you want the artifacts to be versioned:
 
       ![Semver versioning](../assets/user-guide/components/components-edp-versioning.png "Semver versioning")
 

--- a/faq/general-questions.md
+++ b/faq/general-questions.md
@@ -17,9 +17,9 @@ Artifact versioning in KubeRocketCI is designed to ensure each build and deploym
 KubeRocketCI supports two major **versioning schemes**:
 
 - **default**: generates versions based on the branch name and datetime, `BRANCH-DATE-TIME` (e.g. main-20250211-133456).
-- **edp**: structures versions as `MAJOR.MINOR.PATCH-BUILD_ID-TAG`, based on the Semantic Versioning standards. (e.g. build/0.1.0-SNAPSHOT.3).
+- **SemVer**: structures versions as `MAJOR.MINOR.PATCH-BUILD_ID-TAG`, based on the Semantic Versioning standards. (e.g. build/0.1.0-SNAPSHOT.3).
 
-Edp versioning offers more advanced tagging. There are two image tags appended to codebase images:
+SemVer versioning offers more advanced tagging. There are two image tags appended to codebase images:
 
 - **RC**: This tag indicates applications built in release branches. This tag means that these applications are tagged as release candidates (RC).
 - **Snapshot**: This tag marks applications and their versions as snapshots, highlighting that these versions are recommended only for development purposes.

--- a/versioned_docs/version-3.11/user-guide/add-application.md
+++ b/versioned_docs/version-3.11/user-guide/add-application.md
@@ -125,7 +125,7 @@ In the **Advanced Settings** menu, specify the branch options and define the Jir
 
 * **Codebase versioning type** - defines how will the application tag be changed once the new image version is built. There are two versioning types:
   * **default**: Using the `default` versioning type, in order to specify the version of the current artifacts, images, and tags in the Version Control System, a developer should navigate to the corresponding file and change the version **manually**.
-  * **semver**: Using the `semver` versioning type, a developer indicates the version number from which all the artifacts will be versioned and, as a result, **automatically** registered in the corresponding file (e.g. pom.xml). When selecting the `edp` versioning type, the extra fields will appear, type the version number from which you want the artifacts to be versioned:
+  * **semver**: Using the `semver` versioning type, a developer indicates the version number from which all the artifacts will be versioned and, as a result, **automatically** registered in the corresponding file (e.g. pom.xml). When selecting the `semver` versioning type, the extra fields will appear, type the version number from which you want the artifacts to be versioned:
 
       ![Semver versioning](../assets/user-guide/components/components-edp-versioning.png "Semver versioning")
 


### PR DESCRIPTION
## Description

Update all references to EDP versioning in the documentation to use SemVer terminology instead, as per the standardization on Semantic Versioning across the platform. This change ensures consistent terminology in user-facing content.

This PR replaces instances of "EDP versioning" with "SemVer versioning" in documentation files to maintain consistent terminology throughout user-facing content. The changes primarily affect text descriptions in the current documentation, while preserving image references for backwards compatibility.

Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Improvement

## How Has This Been Tested?

Manually reviewed all modified documentation files to verify correct terminology replacement. Checked that all instances of "EDP versioning" were properly updated to "SemVer versioning" where appropriate.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.

## Additional context

This change is part of an effort to standardize on Semantic Versioning terminology throughout the platform documentation. Note that image filenames containing "edp-versioning" were not changed to avoid breaking multiple references across the codebase, but their text descriptions now correctly refer to "SemVer".