### PR TITLE
refactor: Update documentation for /recheck and /ok-to-test commands

### DIFF
--- a/docs/user-guide/tekton-pipelines.md
+++ b/docs/user-guide/tekton-pipelines.md
@@ -99,10 +99,10 @@ Trigger a review pipeline using one of the four methods:
 
   ![Delete branch](../assets/user-guide/tekton-pipelines/review-pipeline-tekton-dashboard-run-again.png "Delete branch")
 
-4. Add a comment with the `/recheck` command on the pull request page:
+4. Add a comment that begins with the `/recheck` or `/ok-to-test` command on the pull request page:
 
 :::note
-The `/recheck` command works for all the available Version Control Systems.
+The `/recheck` and `/ok-to-test` commands must be at the beginning of your comment to be recognized. These commands work for all the available Version Control Systems.
 :::
 
   ![Delete branch](../assets/user-guide/tekton-pipelines/bitbucket-pull-request-recheck.png "Delete branch")

--- a/faq/how-to/developer/missing-review-pipeline-on-pr.md
+++ b/faq/how-to/developer/missing-review-pipeline-on-pr.md
@@ -4,4 +4,4 @@
   <link rel="canonical" href="https://docs.kuberocketci.io/faq/how-to/developer/missing-review-pipeline-on-pr" />
 </head>
 
-If the pipeline does not appear, please use the `/recheck`or `/ok-to-test` comment in the pull request. For more details, read the [KubeRocketCI: Tekton Overview](/docs/user-guide/tekton-pipelines#review-pipeline) page.
+If the pipeline does not appear, please add a comment that begins with `/recheck` or `/ok-to-test` in the pull request. These commands must be at the beginning of your comment to be recognized by the system. For more details, read the [KubeRocketCI: Tekton Overview](/docs/user-guide/tekton-pipelines#review-pipeline) page.

--- a/faq/how-to/developer/retrigger-failed-review-pipeline.md
+++ b/faq/how-to/developer/retrigger-failed-review-pipeline.md
@@ -4,4 +4,4 @@
   <link rel="canonical" href="https://docs.kuberocketci.io/faq/how-to/developer/retrigger-failed-review-pipeline" />
 </head>
 
-Use the `/recheck` or `/ok-to-test` comment in a pull request. Alternative methods are described in the [KubeRocketCI: Tekton Overview](/docs/user-guide/tekton-pipelines#review-pipeline) page.
+Use a comment that begins with `/recheck` or `/ok-to-test` in a pull request. The command must be at the beginning of your comment to be recognized. Alternative methods are described in the [KubeRocketCI: Tekton Overview](/docs/user-guide/tekton-pipelines#review-pipeline) page.

--- a/faq/pipelines.md
+++ b/faq/pipelines.md
@@ -48,10 +48,10 @@ If you need to re-trigger a pipeline due to a failed run or to incorporate new c
 
 - **Tekton Dashboard**: If Tekton Dashboard is integrated. In the KubeRocketCI Portal navigate **Overview** -> **Links** and click on **Tekton**. In the Tekton Dashboard navigate to the **PipelineRuns** section, identify the failed pipeline, and select the action **Rerun**.
 
-- **Through VCS (GitHub/GitLab)**: Add a comment with word `/recheck` or `/ok-to-test` to your Pull Request (PR) or Merge Request (MR), and the pipeline will be triggered automatically.
+- **Through VCS (GitHub/GitLab)**: Add a comment that begins with `/recheck` or `/ok-to-test` to your Pull Request (PR) or Merge Request (MR), and the pipeline will be triggered automatically.
 
 :::tip
-  Use comment approach with `/recheck` or `/ok-to-test` if the Pipeline is not available either on KubeRocketCI or Tekton Dashboard.
+  Use comment approach with `/recheck` or `/ok-to-test` if the Pipeline is not available either on KubeRocketCI or Tekton Dashboard. The command must be at the beginning of your comment to be recognized.
 :::
 
 ---

--- a/versioned_docs/version-3.11/user-guide/tekton-pipelines.md
+++ b/versioned_docs/version-3.11/user-guide/tekton-pipelines.md
@@ -99,10 +99,10 @@ Trigger a review pipeline using one of the four methods:
 
   ![Delete branch](../assets/user-guide/tekton-pipelines/review-pipeline-tekton-dashboard-run-again.png "Delete branch")
 
-4. Add a comment with the `/recheck` command on the pull request page:
+4. Add a comment that begins with the `/recheck` or `/ok-to-test` command on the pull request page:
 
 :::note
-The `/recheck` command works for all the available Version Control Systems.
+The `/recheck` and `/ok-to-test` commands must be at the beginning of your comment to be recognized. These commands work for all the available Version Control Systems.
 :::
 
   ![Delete branch](../assets/user-guide/tekton-pipelines/bitbucket-pull-request-recheck.png "Delete branch")


### PR DESCRIPTION
* Clarify that /recheck and /ok-to-test commands must be at the beginning of PR comments
* Update FAQ entries to include position requirement
* Ensure consistent information across all documentation

Relates to commit 7650f13ef9621919277d9f9549c1729c0f357a0b in the epam/edp-tekton

