### PR TITLE
docs: Add support for PNPM build tool

### DIFF
--- a/docs/about-platform.md
+++ b/docs/about-platform.md
@@ -39,7 +39,7 @@ The platform consists of the following blocks:
   |C|None|Make,CMake|:white_check_mark:|||
   |C++|None|Make,CMake|:white_check_mark:|||
   |Go|Beego, Gin, Operator SDK|Go|:white_check_mark:|||
-  |JavaScript|React, Vue, Angular, Express, Next.js, Antora|NPM|:white_check_mark:|:white_check_mark:||
+  |JavaScript|React, Vue, Angular, Express, Next.js, Antora|NPM, PNPM|:white_check_mark:|:white_check_mark:||
   |HCL|Terraform|Terraform||:white_check_mark:||
   |Helm|Helm, Pipeline|Helm||:white_check_mark:||
   |Groovy|Codenarc|Codenarc||:white_check_mark:||

--- a/docs/user-guide/add-application.md
+++ b/docs/user-guide/add-application.md
@@ -93,7 +93,7 @@ Follow the instructions below to fill in the fields of the **Codebase Info** men
     * **Select Build Tool** -  allows to choose the build tool to use. A set tools and can be changed in accordance with the selected code language.
 
       * Java - selecting Java allows using the Gradle or Maven tool.
-      * JavaScript - selecting JavaScript allows using the NPM tool.
+      * JavaScript - selecting JavaScript allows using the NPM or PNPM tool.
       * C# - selecting C# allows using the .Net tool.
       * Python - selecting Python allows using Python tool.
       * Go - selecting Go allows using Go tool.

--- a/package.json
+++ b/package.json
@@ -59,5 +59,6 @@
   },
   "engines": {
     "node": ">=18.0"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
Description
Added documentation support for the pnpm build tool.

Updated the build tool selection documentation to include PNPM as an available option for JavaScript projects.

Updated the technology support matrix table to reflect PNPM as a supported build tool.

This change improves clarity for users choosing build tools and aligns with the newly added support for PNPM across Tekton tasks and pipelines.

Type of change
- [x] New feature (non-breaking change which adds functionality)

Checklist
- [x] I have performed a self-review of my own code

- [x] I have commented my code, particularly in hard-to-understand areas (N/A)

- [x] I have made corresponding changes to the documentation

- [x] My changes generate no new warnings

- [x] Pull Request contain one commit. I squash my commits.


PNPM is now supported in the Tekton-based CI/CD process. This update reflects that support in the documentation to guide users in selecting the appropriate build tool for JavaScript applications.