### PR TITLE
docs: Deprecate Java8,11 in docs (#496)

### DIFF
--- a/docs/about-platform.md
+++ b/docs/about-platform.md
@@ -27,13 +27,13 @@ The platform consists of the following blocks:
 ## Features
 
 - Deployed and configured CI/CD toolset ([Tekton](https://tekton.dev/), [ArgoCD](https://argoproj.github.io/cd/), [Nexus Repository Manager](https://help.sonatype.com/en/sonatype-nexus-repository.html), [SonarQube](https://www.sonarsource.com/), [DefectDojo](https://www.defectdojo.org/), [Dependency-Track](https://dependencytrack.org/)).
-- [GitHub](https://about.gitlab.com/features/)(by default) or [GitLab](https://about.gitlab.com/features/).
+- [GitHub](https://about.gitlab.com/features/)(by default), [GitLab](https://about.gitlab.com/features/), [Bitbucket](https://www.atlassian.com/software/bitbucket/features/pipelines) or [Gerrit](https://gerrit-review.googlesource.com/Documentation/intro-quick.html).
 - [Tekton](./operator-guide/install-tekton.md) is a pipeline orchestrator.
 - [CI pipelines](./user-guide/index.md) for polyglot applications:
 
   |Language|Framework|Build Tool|Application|Library|Autotest|
   |:-|:-:|:-:|:-:|:-:|:-:|
-  |Java|Java 8, Java 11, Java 17, Java 21|Gradle, Maven|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+  |Java|Java 17, Java 21|Gradle, Maven|:white_check_mark:|:white_check_mark:|:white_check_mark:|
   |Python|Python 3.8, FastAPI, Flask|Python|:white_check_mark:|:white_check_mark:||
   |C#|.Net 3.1, .Net 6.0|.Net|:white_check_mark:|:white_check_mark:||
   |C|None|Make,CMake|:white_check_mark:|||
@@ -45,6 +45,10 @@ The platform consists of the following blocks:
   |Groovy|Codenarc|Codenarc||:white_check_mark:||
   |Rego|OPA|OPA||:white_check_mark:||
   |Container|Docker|Kaniko||:white_check_mark:||
+
+:::note
+As of KubeRocketCI version 3.12, Java 8 and Java 11 frameworks have been deprecated.
+:::
 
 - [Portal UI](./user-guide/index.md) as a single entry point
 - [Deployment Flows](./user-guide/add-cd-pipeline.md) for Microservice Deployment

--- a/docs/user-guide/add-application.md
+++ b/docs/user-guide/add-application.md
@@ -77,7 +77,7 @@ Follow the instructions below to fill in the fields of the **Codebase Info** men
 
     * **Application Code Language** - defines the code language with its supported frameworks:
 
-      * Java – selecting specific Java version (8,11,17 are available).
+      * Java – selecting a specific Java version (17 and 21 are available; Java 8 and 11 deprecated since v3.12).
       * JavaScript - selecting JavaScript allows using React, Vue, Angular, Express, Next.js and Antora frameworks.
       * Python - selecting Python allows using the Python v.3.8, FastAPI, Flask frameworks.
       * Go - selecting Go allows using the Beego, Gin and Operator SDK frameworks.

--- a/docs/user-guide/add-autotest.md
+++ b/docs/user-guide/add-autotest.md
@@ -74,7 +74,7 @@ In our case, we will use the **Clone** strategy:
 2. Specify the autotest language properties:
 
     * **Autotest code language** - defines the code language with its supported frameworks. Selecting **Other** allows extending the default code languages and get the necessary build tool.
-    * **Language version/framework** - defines the specific framework or language version of the autotest. The field depends on the selected code language. Specify Java 8, Java 11, Java 17 or Java 21 to be used.
+    * **Language version/framework** - defines the specific framework or language version of the autotest. The field depends on the selected code language. Specify Java 17 or Java 21 to be used. Java 8 and 11 have been deprecated starting from KubeRocketCI version 3.12.
     * **Build Tool** - allows to choose the build tool to use. In case of autotests, Gradle and Maven are available.
     * **Autotest report framework** - all the autotest reports will be created in the Allure framework by default.
 

--- a/docs/user-guide/add-library.md
+++ b/docs/user-guide/add-library.md
@@ -78,7 +78,7 @@ In our example, we will use the **Create from template** strategy:
 
     * **Library code language** - defines the code language with its supported frameworks:
 
-      * Java – selecting specific Java version available.
+      * Java – selecting specific Java version (17 and 21 are available; Java 8 and 11 deprecated since v3.12).
       * JavaScript - selecting JavaScript allows using the NPM tool.
       * Python - selecting Python allows using the Python v.3.8, FastAPI, Flask.
       * Groovy-pipeline - selecting Groovy-pipeline allows having the ability to customize a stages logic.

--- a/versioned_docs/version-3.12/about-platform.md
+++ b/versioned_docs/version-3.12/about-platform.md
@@ -27,13 +27,13 @@ The platform consists of the following blocks:
 ## Features
 
 - Deployed and configured CI/CD toolset ([Tekton](https://tekton.dev/), [ArgoCD](https://argoproj.github.io/cd/), [Nexus Repository Manager](https://help.sonatype.com/en/sonatype-nexus-repository.html), [SonarQube](https://www.sonarsource.com/), [DefectDojo](https://www.defectdojo.org/), [Dependency-Track](https://dependencytrack.org/)).
-- [GitHub](https://about.gitlab.com/features/)(by default) or [GitLab](https://about.gitlab.com/features/).
+- [GitHub](https://about.gitlab.com/features/)(by default), [GitLab](https://about.gitlab.com/features/), [Bitbucket](https://www.atlassian.com/software/bitbucket/features/pipelines) or [Gerrit](https://gerrit-review.googlesource.com/Documentation/intro-quick.html).
 - [Tekton](./operator-guide/install-tekton.md) is a pipeline orchestrator.
 - [CI pipelines](./user-guide/index.md) for polyglot applications:
 
   |Language|Framework|Build Tool|Application|Library|Autotest|
   |:-|:-:|:-:|:-:|:-:|:-:|
-  |Java|Java 8, Java 11, Java 17, Java 21|Gradle, Maven|:white_check_mark:|:white_check_mark:|:white_check_mark:|
+  |Java|Java 17, Java 21|Gradle, Maven|:white_check_mark:|:white_check_mark:|:white_check_mark:|
   |Python|Python 3.8, FastAPI, Flask|Python|:white_check_mark:|:white_check_mark:||
   |C#|.Net 3.1, .Net 6.0|.Net|:white_check_mark:|:white_check_mark:||
   |C|None|Make,CMake|:white_check_mark:|||
@@ -45,6 +45,10 @@ The platform consists of the following blocks:
   |Groovy|Codenarc|Codenarc||:white_check_mark:||
   |Rego|OPA|OPA||:white_check_mark:||
   |Container|Docker|Kaniko||:white_check_mark:||
+
+:::note
+As of KubeRocketCI version 3.12, Java 8 and Java 11 frameworks have been deprecated.
+:::
 
 - [Portal UI](./user-guide/index.md) as a single entry point
 - [Deployment Flows](./user-guide/add-cd-pipeline.md) for Microservice Deployment

--- a/versioned_docs/version-3.12/user-guide/add-application.md
+++ b/versioned_docs/version-3.12/user-guide/add-application.md
@@ -77,7 +77,7 @@ Follow the instructions below to fill in the fields of the **Codebase Info** men
 
     * **Application Code Language** - defines the code language with its supported frameworks:
 
-      * Java – selecting specific Java version (8,11,17 are available).
+      * Java – selecting a specific Java version (17 and 21 are available; Java 8 and 11 deprecated since v3.12).
       * JavaScript - selecting JavaScript allows using React, Vue, Angular, Express, Next.js and Antora frameworks.
       * Python - selecting Python allows using the Python v.3.8, FastAPI, Flask frameworks.
       * Go - selecting Go allows using the Beego, Gin and Operator SDK frameworks.

--- a/versioned_docs/version-3.12/user-guide/add-autotest.md
+++ b/versioned_docs/version-3.12/user-guide/add-autotest.md
@@ -74,7 +74,7 @@ In our case, we will use the **Clone** strategy:
 2. Specify the autotest language properties:
 
     * **Autotest code language** - defines the code language with its supported frameworks. Selecting **Other** allows extending the default code languages and get the necessary build tool.
-    * **Language version/framework** - defines the specific framework or language version of the autotest. The field depends on the selected code language. Specify Java 8, Java 11, Java 17 or Java 21 to be used.
+    * **Language version/framework** - defines the specific framework or language version of the autotest. The field depends on the selected code language. Specify Java 17 or Java 21 to be used. Java 8 and 11 have been deprecated starting from KubeRocketCI version 3.12.
     * **Build Tool** - allows to choose the build tool to use. In case of autotests, Gradle and Maven are available.
     * **Autotest report framework** - all the autotest reports will be created in the Allure framework by default.
 

--- a/versioned_docs/version-3.12/user-guide/add-library.md
+++ b/versioned_docs/version-3.12/user-guide/add-library.md
@@ -78,7 +78,7 @@ In our example, we will use the **Create from template** strategy:
 
     * **Library code language** - defines the code language with its supported frameworks:
 
-      * Java – selecting specific Java version available.
+      * Java – selecting specific Java version (17 and 21 are available; Java 8 and 11 deprecated since v3.12).
       * JavaScript - selecting JavaScript allows using the NPM tool.
       * Python - selecting Python allows using the Python v.3.8, FastAPI, Flask.
       * Groovy-pipeline - selecting Groovy-pipeline allows having the ability to customize a stages logic.


### PR DESCRIPTION
## Description

As of version 3.12, we have deprecated the Java 8 and Java 11 framework support. We should notify users about it in documentation.
Fixes #(issue)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement

## How Has This Been Tested?

npm ci && npm start && yarn spell-check

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.
