### PR TITLE
EPMDEDP-17217: docs: Improve SEO metadata, interlinking, and technical SEO across auth guides and blog

### DIFF
--- a/blog/2024-12-03/aws-eks-microsoft-entra-oidc-integration.md
+++ b/blog/2024-12-03/aws-eks-microsoft-entra-oidc-integration.md
@@ -1,6 +1,6 @@
 ---
 title: "Integrating OIDC Authentication with Microsoft Entra in AWS EKS"
-description: "Learn how to implement Single Sign-On (SSO) using OpenID Connect (OIDC) and Microsoft Entra to enhance security and streamline authentication processes in Amazon Elastic Kubernetes Service (AWS EKS)."
+description: "Microsoft Entra OIDC integration secures AWS EKS with Single Sign-On: configure OIDC, RBAC, and KubeRocketCI Portal login step by step."
 slug: integrating-oidc-authentication-microsoft-entra-aws-eks
 tags: [KubeRocketCI, AWS EKS, SSO, Microsoft Entra, OIDC, Kubernetes, Security]
 keywords: [KubeRocketCI, Microsoft Entra, AWS EKS, Kubernetes, AWS, EKS, IAM, OpenID Connect, Single Sign-On, Security, Authentication, Authorization]
@@ -15,15 +15,21 @@ In modern cloud environments, secure and efficient access management is essentia
 
 <!--truncate-->
 
+:::info
+**Updated: July 2026** — Links verified and integration steps re-checked against the current Microsoft Entra admin center.
+:::
+
 ## Prerequisites
 
 Before you begin, ensure you have the following:
 
-- Access to the [Microsoft Entra Admin Center](https://entra.microsoft.com/?feature.msaljs=true#home) with administrative privileges.
+- Access to the [Microsoft Entra Admin Center](https://entra.microsoft.com/) with administrative privileges.
 - A running [AWS EKS](https://docs.aws.amazon.com/eks/latest/userguide/create-cluster.html) cluster with the necessary permissions for access and management.
 - The [kubelogin](https://github.com/int128/kubelogin) plugin installed for authenticating to the EKS cluster using OIDC.
 - The [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) CLI tool installed.
 - The [aws cli](https://aws.amazon.com/cli/) tool installed.
+
+If you use Keycloak instead of Microsoft Entra, see [Keycloak OIDC for EKS](/docs/operator-guide/auth/configure-keycloak-oidc-eks).
 
 ## Understanding SSO, OIDC, and Microsoft Entra
 
@@ -45,7 +51,7 @@ Microsoft Entra, formerly known as Azure Active Directory (Azure AD), is a moder
 
 To get started with Microsoft Entra, you need to create a new tenant in the Microsoft Entra Admin Center. Follow these steps:
 
-1. Log in to the [Microsoft Entra Admin Center](https://entra.microsoft.com/?feature.msaljs=true#home) using your Microsoft account.
+1. Log in to the [Microsoft Entra Admin Center](https://entra.microsoft.com/) using your Microsoft account.
 
     ![Microsoft Entra Admin Center](../assets/aws-eks-microsoft-entra-oidc-integration/microsoft-entra-admin-center.png)
 
@@ -184,7 +190,7 @@ The Application data, such as **Directory (tenant) ID**, **Application (client) 
 
 ### Method 1: Using the AWS Management Console
 
-1. Log in to the [AWS Management Console](https://aws.amazon.com/console/) and navigate to the [Amazon EKS console](https://console.aws.amazon.com/eks/). Select the EKS cluster you want to configure and click on the **Access** tab.
+1. Log in to the [AWS Management Console](https://aws.amazon.com/console/) and navigate to the [Amazon EKS console](https://console.aws.amazon.com/eks). Select the EKS cluster you want to configure and click on the **Access** tab.
 
     ![EKS Cluster Access Tab](../assets/aws-eks-microsoft-entra-oidc-integration/eks-cluster-access-tab.png)
 
@@ -242,6 +248,10 @@ To configure Microsoft Entra as an Identity Provider in AWS EKS using Terraform,
       cluster_identity_providers = var.cluster_identity_providers
     }
     ```
+
+:::note
+You may notice the issuer URL format differs between methods: the AWS Console example above uses `https://login.microsoftonline.com/<Tenant-ID>/` (Entra v2), while this Terraform example uses `https://sts.windows.net/<Tenant ID>/` (the legacy Entra v1 format). Both are valid, but the issuer you configure must match the `iss` claim of the tokens your app registration actually issues, so check the app's manifest `accessTokenAcceptedVersion` setting before choosing one.
+:::
 
 After applying the Terraform configuration, the Microsoft Entra OIDC identity provider will be associated with the AWS EKS cluster.
 
@@ -361,6 +371,14 @@ To authenticate to the AWS EKS cluster using Microsoft Entra, you can use the `k
 
     ![Sign In](../assets/aws-eks-microsoft-entra-oidc-integration/sign-in.png)
 
+If the Portal sits behind an OAuth2 proxy, see [OAuth2 Proxy](/docs/operator-guide/auth/oauth2-proxy) for the general setup and [Microsoft Entra OAuth2 Proxy Authentication](/docs/operator-guide/microsoft-entra/oauth2-proxy-authentication) for the Entra-specific configuration.
+
 ## Conclusion
 
 Integrating OpenID Connect (OIDC) authentication with Microsoft Entra in AWS EKS is a powerful way to enhance security and streamline user access management. By leveraging the capabilities of SSO, OIDC, and Microsoft Entra, organizations can simplify authentication processes, enforce access controls, and ensure secure navigation across cloud-native environments. Whether you're managing user identities, enhancing compliance, or improving user experience, this integration provides a robust solution to meet your identity and access management needs. By following the steps outlined in this guide, you can configure Microsoft Entra as an Identity Provider in AWS EKS, authenticate users using OIDC, and secure access to your EKS clusters and KubeRocketCI Portal effectively.
+
+**Related reading:**
+
+- [Advanced AWS EKS Management: Implementing SSO via OIDC and Keycloak](/blog/advanced-aws-eks-management-oidc-keycloak) - the same OIDC pattern for AWS EKS, using Keycloak as the identity provider instead of Microsoft Entra.
+- [Keycloak OIDC for EKS](/docs/operator-guide/auth/configure-keycloak-oidc-eks) - the docs reference for the Keycloak-based setup.
+- [OAuth2 Proxy](/docs/operator-guide/auth/oauth2-proxy) and [Microsoft Entra OAuth2 Proxy Authentication](/docs/operator-guide/microsoft-entra/oauth2-proxy-authentication) - securing the KubeRocketCI Portal behind an OAuth2 proxy.

--- a/blog/2026-06-07/ephemeral-preview-environments-kubernetes-feature-branch.md
+++ b/blog/2026-06-07/ephemeral-preview-environments-kubernetes-feature-branch.md
@@ -1,6 +1,6 @@
 ---
-title: "Ephemeral Environments on Kubernetes: Feature Branch Preview Walkthrough"
-description: "Spin up isolated ephemeral preview environments on Kubernetes from a feature branch with KubeRocketCI, Tekton, and Argo CD. Open source, no SaaS bill."
+title: "Ephemeral Preview Environments on Kubernetes"
+description: "Spin up per-feature-branch preview environments on Kubernetes with KubeRocketCI, Tekton, and Argo CD — isolated namespaces, auto-cleanup, no SaaS bill."
 slug: ephemeral-preview-environments-kubernetes-feature-branch
 tags: [KubeRocketCI, Preview Environments, Ephemeral Environments, GitOps, Argo CD, Tekton, Kubernetes, Feature Branch, CD, Platform Engineering, CI/CD, Open Source]
 keywords: [ephemeral environments kubernetes, preview environments kubernetes, feature branch deployment kubernetes, self-hosted preview environments kubernetes, open source preview environments kubernetes, pull request preview environment kubernetes, per-PR environments kubernetes, dynamic environments kubernetes, on-demand environments kubernetes, GitOps preview environments Argo CD, Tekton Argo CD preview environment, kubernetes namespace isolation per feature branch, per environment values override gitops helm, internal developer platform preview environments, destroy kubernetes namespace zero residual cost, open source alternative okteto uffizzi bunnyshell]
@@ -11,7 +11,7 @@ last_update:
   date: 2026-06-07
 ---
 
-# Ephemeral Environments on Kubernetes: Feature Branch Preview Walkthrough
+# Ephemeral Preview Environments on Kubernetes
 
 An ephemeral preview environment is an isolated, temporary Kubernetes deployment created from a single feature branch and torn down when the work is done. Every branch gets its own namespace, its own image, its own URL - and zero of it lingers afterward. Ephemeral environments on Kubernetes make this pattern available on your own cluster - but a hands-on, open-source, portal-native version - feature branch to isolated namespace to one-click destroy, backed by real Tekton CI and Argo CD GitOps - is conspicuously missing from the public record.
 

--- a/blog/2026-06-08/gitlab-ci-integration-kuberocketci.md
+++ b/blog/2026-06-08/gitlab-ci-integration-kuberocketci.md
@@ -3,7 +3,7 @@ title: "GitLab CI Integration in KubeRocketCI"
 description: "How KubeRocketCI runs CI in GitLab CI instead of Tekton: onboard the CI/CD components, create the ConfigMap, add a Runner. A hands-on multi-CI walkthrough."
 slug: gitlab-ci-integration-kuberocketci
 tags: [KubeRocketCI, GitLab CI, CI/CD, Tekton, Kubernetes, GitLab Runner, Multi-CI, GitOps, Platform Engineering, DevOps, Open Source]
-keywords: [gitlab ci integration, gitlab ci kubernetes, kuberocketci gitlab ci, gitlab ci instead of tekton, multi-ci kubernetes platform, ciTool gitlab, gitlab ci/cd components kubernetes, gitlab runner kubernetes executor, self-hosted gitlab ci kubernetes, tekton vs gitlab ci, internal developer platform gitlab ci, gitlab ci configmap template, codebase-operator gitlab-ci.yml injection, gitlab ci component mirror, gitlab container registry buildkit, gitlab merge request pipeline kubernetes, how gitlab ci integration works]
+keywords: [gitlab ci integration, gitlab ci kubernetes, kuberocketci gitlab ci, gitlab ci instead of tekton, multi-ci kubernetes platform, ciTool gitlab, gitlab ci/cd components kubernetes, gitlab runner kubernetes executor, self-hosted gitlab ci kubernetes, internal developer platform gitlab ci, gitlab ci configmap template, codebase-operator gitlab-ci.yml injection, gitlab ci component mirror, gitlab container registry buildkit, gitlab merge request pipeline kubernetes, how gitlab ci integration works]
 image: https://docs.kuberocketci.io/img/kuberocketci-social-card.jpg
 authors: [sergk]
 hide_table_of_contents: false

--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -6,6 +6,7 @@ dictionaries:
   - python
   - softwareTerms
 words:
+  - AADSTS
   - addopts
   - adoptopenjdk
   - alnum

--- a/docs/operator-guide/auth/configure-keycloak-oidc-eks.md
+++ b/docs/operator-guide/auth/configure-keycloak-oidc-eks.md
@@ -1,6 +1,6 @@
 ---
-title: "EKS OIDC With Keycloak"
-description: "Step-by-step guide on configuring Keycloak as OIDC Identity Provider for EKS, enabling Single Sign-On capabilities for enhanced security."
+title: "Keycloak as OIDC Provider for AWS EKS"
+description: "Configure Keycloak as the OIDC provider for AWS EKS: create clients and groups, associate the provider, and map RBAC roles for SSO kubectl access."
 sidebar_label: "EKS OIDC With Keycloak"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -14,26 +14,31 @@ import TabItem from '@theme/TabItem';
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/auth/configure-keycloak-oidc-eks" />
 </head>
 
-This article provides the instruction of configuring Keycloak as [OIDC Identity Provider](https://aws.amazon.com/blogs/containers/introducing-oidc-identity-provider-authentication-amazon-eks/) for EKS.
-The example is implemented following the KubeRocketCI add-ons approach.
+Configure Keycloak as the OIDC identity provider for an AWS EKS cluster so users can log in to `kubectl` with their existing Keycloak/SSO credentials instead of static IAM users. This guide walks through creating the Keycloak client and groups, associating Keycloak as an EKS OIDC provider (via Terraform or the AWS Console), and mapping Keycloak groups to Kubernetes RBAC roles — following the KubeRocketCI add-ons approach.
+
+For provisioning the underlying Keycloak realm/client/group resources through the Keycloak operator's Custom Resources, see [Provision Keycloak Resources for EKS OIDC](eks-oidc-integration.md).
 
 ## Prerequisites
 
-To follow the instruction, check the following prerequisites:
+### Required
 
-1. (Optional) Terraform version 1.5.7
-2. Kubelogin version >= v1.25.1
-3. (Optional) [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied
-4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets)
-5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak)
-6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed
-7. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible
+1. The [kubelogin](https://github.com/int128/kubelogin) plugin, installed and configured to connect OIDC with a cluster. For Windows, it is recommended to download the kubelogin as a binary and add it to your PATH. Use the [latest kubelogin release](https://github.com/int128/kubelogin/releases).
+2. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak).
+3. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed.
+4. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible.
 
-:::note
-  To connect OIDC with a cluster, install and configure the [kubelogin](https://github.com/int128/kubelogin) plugin. For Windows, it is recommended to download the kubelogin as a binary and add it to your PATH.
-:::
+<details>
+<summary>Optional prerequisites</summary>
+
+- A recent Terraform 1.x release, if associating the EKS OIDC provider via Terraform instead of the AWS Console.
+- [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied.
+- [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets), if managing Keycloak credentials as synced secrets rather than manually.
+
+</details>
 
 ## Solution Overview
+
+By the end of this guide, Keycloak groups will be mapped to Kubernetes RBAC roles, letting users authenticate to the EKS cluster with `kubectl` using their Keycloak credentials instead of static IAM users.
 
 This architecture encompasses three primary resource types: AWS (EKS), Keycloak, and Kubernetes.
 Within this setup, the Keycloak resources, once established, remain static, facilitating the assignment of claims based on user group memberships. This stability contrasts with the dynamic nature of other resources, which may be created, modified, or deleted as necessary.
@@ -105,7 +110,7 @@ The initial step involves setting up the Keycloak operator (configure connection
     ```
 
 
-This add-ons facilitates sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including to EKS, Sonar, Nexus, and Portal.
+This add-on sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including EKS, Sonar, Nexus, and Portal.
 
 The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
 
@@ -289,6 +294,9 @@ To access the Kubernetes cluster via [Lens](https://k8slens.dev/), follow the st
 
 By default, the Keycloak token has a lifespan of 5 minutes. To modify this duration refer to the guidelines outlined in this [document](ui-portal-oidc.md#changing-the-lifespan-of-an-access-token).
 
+For application-level OIDC via OAuth2-Proxy rather than cluster `kubectl` access, see [Tekton Dashboard Authentication](./oauth2-proxy.md). Using Microsoft Entra instead of Keycloak? See [AWS EKS OIDC With Microsoft Entra](../microsoft-entra/aws-eks-portal-authentication.md).
+
 ## Related Articles
 
 * [Headlamp OIDC Configuration](ui-portal-oidc.md)
+* [Provision Keycloak Resources for EKS OIDC](eks-oidc-integration.md)

--- a/docs/operator-guide/auth/eks-oidc-integration.md
+++ b/docs/operator-guide/auth/eks-oidc-integration.md
@@ -1,6 +1,6 @@
 ---
-title: "AWS EKS OIDC Integration"
-description: "Comprehensive guide on integrating Keycloak with AWS EKS for OIDC authentication, enhancing security with Single Sign-On capabilities."
+title: "Provision Keycloak Resources for EKS OIDC"
+description: "Provision Keycloak realm, client, and group resources for AWS EKS OIDC through the edp-keycloak-operator Custom Resources, installed via Helm."
 sidebar_label: "AWS EKS OIDC Integration"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -11,12 +11,12 @@ sidebar_label: "AWS EKS OIDC Integration"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/auth/eks-oidc-integration" />
 </head>
 
-This page serves as a comprehensive guide on integrating Keycloak with the [edp-keycloak-operator](https://github.com/epam/edp-keycloak-operator) to act as an identity provider for AWS Elastic Kubernetes Service (EKS). It provides detailed step-by-step instructions for creating the necessary realms, users, roles, and client configurations to seamlessly collaborate between Keycloak and EKS. Additionally, it includes instructions on installing the edp-keycloak-operator using Helm charts.
+This page shows how to provision the Keycloak realm, client, group, and user resources needed for EKS OIDC by installing the [edp-keycloak-operator](https://github.com/epam/edp-keycloak-operator) via Helm and applying its Custom Resources — `Keycloak`, `KeycloakRealm`, `KeycloakRealmGroup`, `KeycloakClientScope`, `KeycloakClient`, and `KeycloakRealmUser`. It covers only the Keycloak-side resource provisioning; for the end-to-end setup of EKS cluster access — associating Keycloak as the EKS OIDC provider and mapping groups to Kubernetes RBAC roles — see [Keycloak as OIDC Provider for AWS EKS](./configure-keycloak-oidc-eks.md).
 
 ## Prerequisites
 
 - [EKS Configuration](./configure-keycloak-oidc-eks.md) is performed
-- [Helm v3.10.0](https://github.com/helm/helm/releases/tag/v3.10.0) is installed
+- A recent Helm 3.x release is installed
 - [Keycloak](../../operator-guide/auth/keycloak.md) is installed
 
 ## Install Keycloak Operator

--- a/docs/operator-guide/auth/keycloak.md
+++ b/docs/operator-guide/auth/keycloak.md
@@ -1,6 +1,6 @@
 ---
 title: "Install Keycloak"
-description: "Comprehensive guide on installing Keycloak within KubeRocketCI for robust identity and access management, including prerequisites and configuration steps."
+description: "Install Keycloak on Kubernetes and configure it with the EDP Keycloak Operator: PostgreSQL setup, Helm installation, and operator-managed realms."
 sidebar_label: "Install Keycloak"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -356,7 +356,7 @@ To install Keycloak, follow the steps below:
 
     </details>
 
-## Configuration
+## Configure Keycloak with the EDP Keycloak Operator {#configuration}
 
 For configuring Keycloak within your environment, it's recommended to utilize the [edp-keycloak-operator](https://github.com/epam/edp-keycloak-operator).
 This operator simplifies the integration process by automating the deployment and management of Keycloak instances.

--- a/docs/operator-guide/devsecops/defectdojo.md
+++ b/docs/operator-guide/devsecops/defectdojo.md
@@ -1,6 +1,6 @@
 ---
-title: "Integrate DefectDojo"
-description: "Guide on integrating DefectDojo with KubeRocketCI for vulnerability management, including installation steps and configuring DefectDojo for CI/CD integration."
+title: "Install and Integrate DefectDojo"
+description: "Install DefectDojo on Kubernetes with Helm and integrate it with KubeRocketCI pipelines: step-by-step setup for CI/CD vulnerability management."
 sidebar_label: "Integrate DefectDojo"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/devsecops/defectdojo" />
 </head>
 
-Inspect the main steps to perform for installing DefectDojo via Helm Chart.
+Install DefectDojo on Kubernetes with Helm and integrate it into KubeRocketCI pipelines for vulnerability management. Once installed, you can enable single sign-on by following the [DefectDojo Microsoft Entra OIDC SSO Setup](../microsoft-entra/defectdojo-oidc-authentication.md) guide.
 
 :::info
   It is also possible to install DefectDojo using the add-ons approach. For details, please refer to the [KubeRocketCI addons approach](https://github.com/epam/edp-cluster-add-ons).
@@ -332,3 +332,4 @@ After following the instructions provided, you should be able to integrate your 
 * [Install External Secrets Operator](../secrets-management/install-external-secrets-operator.md)
 * [External Secrets Operator Integration](../secrets-management/external-secrets-operator-integration.md)
 * [Install Harbor](../artifacts-management/harbor-installation.md)
+* [DefectDojo Microsoft Entra OIDC SSO Setup](../microsoft-entra/defectdojo-oidc-authentication.md)

--- a/docs/operator-guide/devsecops/dependency-track.md
+++ b/docs/operator-guide/devsecops/dependency-track.md
@@ -107,3 +107,4 @@ After following the instructions provided, you should be able to integrate your 
 * [Install External Secrets Operator](../secrets-management/install-external-secrets-operator.md)
 * [External Secrets Operator Integration](../secrets-management/external-secrets-operator-integration.md)
 * [Cluster Add-Ons Overview](../add-ons-overview.md)
+* [Dependency-Track Microsoft Entra OIDC SSO](../microsoft-entra/dependency-track-authentication.md)

--- a/docs/operator-guide/infrastructure-providers/aws/ebs-csi-driver.md
+++ b/docs/operator-guide/infrastructure-providers/aws/ebs-csi-driver.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Amazon EBS CSI Driver"
-description: "Enable Amazon EKS clusters to manage Amazon EBS volumes with the EBS CSI driver, covering prerequisites, IAM setup, and add-on installation."
+title: "AWS EBS CSI Driver Setup for EKS"
+description: "Step-by-step guide to setting up the AWS EBS CSI driver on Amazon EKS: IAM OIDC prerequisites, trust policy, IAM role, and add-on install."
 sidebar_label: "Amazon EBS CSI Driver"
 
 ---
@@ -13,7 +13,7 @@ sidebar_label: "Amazon EBS CSI Driver"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/infrastructure-providers/aws/ebs-csi-driver" />
 </head>
 
-The Amazon Elastic Block Store (Amazon EBS) Container Storage Interface (CSI) driver allows Amazon Elastic Kubernetes Service (Amazon EKS) clusters to manage the lifecycle of Amazon EBS volumes for Kubernetes Persistent Volumes.
+This guide shows how to install the AWS EBS CSI driver on an Amazon EKS cluster, step by step: creating the IAM OIDC trust policy, attaching the AWS-managed IAM policy, and deploying the driver as an EKS add-on so Kubernetes can manage Amazon EBS-backed Persistent Volumes.
 
 ## Prerequisites
 

--- a/docs/operator-guide/microsoft-entra/argo-cd-authentication.md
+++ b/docs/operator-guide/microsoft-entra/argo-cd-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Argo CD"
-description: "Learn how to configure OIDC authentication for Argo CD using Microsoft Entra as the Identity Provider, ensuring secure and efficient access management."
+title: "Argo CD Microsoft Entra OIDC SSO Setup"
+description: "Configure Argo CD SSO with Microsoft Entra OIDC: app registration, group-to-role mapping, and Helm chart configuration guide."
 sidebar_label: "Argo CD"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Argo CD"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/argo-cd-authentication" />
 </head>
 
-This guide provides instructions on how to configure OIDC authentication for the Argo CD using Microsoft Entra as the Identity Provider.
+Configure Argo CD single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping Entra groups to Argo CD RBAC roles, and updating the Argo CD Helm chart — the same platform-access pattern used for the [AWS EKS cluster and KubeRocketCI Portal](./aws-eks-portal-authentication.md).
 
-## Prerequisites
+## Prerequisites for Argo CD SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Argo CD Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for the Argo CD, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -94,7 +94,7 @@ To manage access to the Argo CD, it is necessary to create groups in the Microso
 
 3. Click on the **Create** button and repeat this process for each required group.
 
-## Configuring Argo CD Helm chart
+## Configuring the Argo CD Helm Chart for OIDC
 
 To integrate Argo CD with configured Microsoft Entra Application, it is necessary to configure the Argo CD Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy Argo CD to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -193,6 +193,19 @@ The **Object ID** can be found in the **Overview** section of the group in the M
 
 After completing these steps, the Argo CD will be configured to use Microsoft Entra as the Identity Provider for authentication. Users will be able to log in to the Argo CD using their Microsoft Entra credentials.
 
+## Troubleshooting Argo CD SSO with Microsoft Entra
+
+If the login flow fails after completing the steps above, check the following common causes:
+
+- **Error `AADSTS50011` (redirect URI mismatch) after clicking Log in via Entra.** The Redirect URI registered in the **Authentication** section of the Microsoft Entra Application must exactly match `https://<Argo CD URL>/auth/callback`, including the scheme and any trailing path. Update the application registration and retry.
+- **Login succeeds, but the user sees no applications or projects.** Argo CD RBAC did not match any group. Verify that the **groups claim** is added in the **Token configuration** section with the **Group ID** type, that the group **Object ID** used in the Argo CD RBAC policy matches the group in Microsoft Entra, and that `scopes` in the Helm values includes `groups`.
+- **`invalid client credentials` or an endless login loop.** The client secret has expired or the secret **Secret ID** was copied instead of the secret **Value**. Generate a new client secret in **Certificates & secrets** and update the secret referenced by the Argo CD Helm chart.
+- **The groups claim is missing for some users.** When a user belongs to a large number of groups, Microsoft Entra replaces the group list in the token with an overage claim, and Argo CD cannot evaluate it. Use dedicated, smaller groups for Argo CD access.
+
+To inspect the exact OIDC error, check the `argocd-server` pod logs while reproducing the login attempt.
+
 ## Related Articles
 
+* [AWS EKS & KubeRocketCI Portal Microsoft Entra OIDC SSO](./aws-eks-portal-authentication.md)
+* [Grafana Microsoft Entra OIDC SSO Setup](./grafana-authentication.md)
 * [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/aws-eks-portal-authentication.md
+++ b/docs/operator-guide/microsoft-entra/aws-eks-portal-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With AWS EKS & KubeRocketCI Portal"
-description: "Comprehensive instructions on configuring OIDC authentication for AWS EKS and KubeRocketCI Portal using Microsoft Entra, including default namespace and user picture configuration."
+title: "AWS EKS & Portal Microsoft Entra OIDC SSO"
+description: "Configure Microsoft Entra OIDC for AWS EKS and the KubeRocketCI Portal: default namespace and profile picture via Entra extension attributes."
 sidebar_label: "AWS EKS & KubeRocketCI Portal"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "AWS EKS & KubeRocketCI Portal"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/aws-eks-portal-authentication" />
 </head>
 
-This guide provides instructions on how to configure OpenID Connect (OIDC) authentication for the AWS EKS cluster and the KubeRocketCI Portal using Microsoft Entra as the Identity Provider (IdP), as well as how to configure the default namespace and user picture in the KubeRocketCI Portal using Microsoft Entra extension attributes.
+Configure Microsoft Entra as the OIDC identity provider for both the AWS EKS cluster and the KubeRocketCI Portal, then use Entra extension attributes to auto-populate each user's default namespace and profile picture on login. This platform-access setup pairs naturally with [Argo CD Microsoft Entra SSO](./argo-cd-authentication.md) for a single sign-on experience across the deployment stack.
 
-## Prerequisites
+## Prerequisites for AWS EKS & Portal SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -418,4 +418,5 @@ Follow the steps below to configure and assign a custom Token Lifetime Policy to
 
 ## Related Articles
 
+* [Argo CD Microsoft Entra OIDC SSO Setup](./argo-cd-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/awx-operator-authentication.md
+++ b/docs/operator-guide/microsoft-entra/awx-operator-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Ansible AWX"
-description: "Step-by-step instructions on configuring Ansible AWX with OIDC authentication using Microsoft Entra as the Identity Provider for enhanced security."
+title: "Ansible AWX Microsoft Entra OIDC SSO"
+description: "Configure Ansible AWX SSO with Microsoft Entra OIDC: app registration, client secret, and Azure AD authentication settings guide."
 sidebar_label: "Ansible AWX"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Ansible AWX"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/awx-operator-authentication" />
 </head>
 
-This guide provides instructions on how to configure Ansible AWX with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure Ansible AWX single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application and entering the resulting client credentials into the AWX Azure AD authentication settings — see the [Microsoft Entra OIDC overview](./oidc-authentication-overview.md) for the full list of KubeRocketCI add-ons that follow this same pattern.
 
-## Prerequisites
+## Prerequisites for Ansible AWX SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -23,7 +23,7 @@ Before you begin, make sure the following prerequisites are met:
 - [Microsoft Entra](https://learn.microsoft.com/en-us/entra/fundamentals/create-new-tenant) Tenant is created.
 - Ansible AWX is installed using the [AWX Operator](https://github.com/ansible-community/awx-operator-helm).
 
-## Configuring Microsoft Entra Application
+## Registering the Ansible AWX Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for the Ansible AWX, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -88,4 +88,5 @@ After completing these steps, the Ansible AWX will be configured to use OIDC aut
 
 ## Related Articles
 
+* [OpenSearch Microsoft Entra OIDC SSO Setup](./opensearch-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/defectdojo-oidc-authentication.md
+++ b/docs/operator-guide/microsoft-entra/defectdojo-oidc-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With DefectDojo"
-description: "Comprehensive guide on configuring DefectDojo with OIDC authentication using Microsoft Entra as the Identity Provider for secure access management."
+title: "DefectDojo Microsoft Entra OIDC SSO Setup"
+description: "Set up DefectDojo SSO with Microsoft Entra OIDC: app registration and Helm chart configuration for secure DevSecOps platform access."
 sidebar_label: "DefectDojo"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "DefectDojo"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/defectdojo-oidc-authentication" />
 </head>
 
-This guide provides instructions on how to configure DefectDojo with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Set up DefectDojo single sign-on using Microsoft Entra as the OIDC identity provider. This guide walks through registering the Microsoft Entra application, configuring redirect URIs, and updating the DefectDojo Helm chart so vulnerability-management access is centrally managed alongside the rest of your DevSecOps stack, including [Dependency-Track](./dependency-track-authentication.md).
 
-## Prerequisites
+## Prerequisites for DefectDojo SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the DefectDojo Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for DefectDojo, it is necessary to create and configure an Application in the Microsoft Entra Admin Center.
 
@@ -61,7 +61,7 @@ To configure Microsoft Entra as the Identity Provider for DefectDojo, it is nece
 
     ![API permissions](../../assets/operator-guide/microsoft-entra-auth/defectdojo-api-permissions.png)
 
-## Configuring DefectDojo Helm chart
+## Configuring the DefectDojo Helm Chart for OIDC
 
 To integrate DefectDojo with configured Microsoft Entra Application, it is necessary to configure the DefectDojo Helm chart.
 In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy DefectDojo to the Kubernetes (e.g. AWS EKS) cluster.
@@ -153,6 +153,7 @@ The Application data, such as **Application (client) ID** and **Directory (tenan
 
 6. After successfully verifying the login, you can proceed with configuring specific permissions for each logged-in user directly within the DefectDojo application.
 
-## Related articles
+## Related Articles
 
+- [Dependency-Track Microsoft Entra OIDC SSO](./dependency-track-authentication.md)
 - [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/dependency-track-authentication.md
+++ b/docs/operator-guide/microsoft-entra/dependency-track-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Dependency-Track"
-description: "Learn how to configure Dependency-Track with OIDC authentication using Microsoft Entra as the Identity Provider for secure and efficient access management."
+title: "Dependency-Track Microsoft Entra OIDC SSO"
+description: "Configure Dependency-Track SSO with Microsoft Entra OIDC: app registration and Helm chart setup for secure vulnerability-management access."
 sidebar_label: "Dependency-Track"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Dependency-Track"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/dependency-track-authentication" />
 </head>
 
-This guide provides instructions on how to configure Dependency-Track with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure Dependency-Track single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping access groups, and updating the Dependency-Track Helm chart — pairing naturally with [DefectDojo SSO](./defectdojo-oidc-authentication.md) if you run both scanners in your DevSecOps pipeline.
 
-## Prerequisites
+## Prerequisites for Dependency-Track SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - [Crunchy PostgreSQL Operator](https://github.com/CrunchyData/postgres-operator) is installed.
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 
-## Configuring Microsoft Entra Application
+## Registering the Dependency-Track Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Dependency-Track, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -86,7 +86,7 @@ To manage access to Dependency-Track, it is necessary to create the groups in Mi
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring Dependency-Track Helm chart
+## Configuring the Dependency-Track Helm Chart for OIDC
 
 To integrate Dependency-Track with configured Microsoft Entra Application, it is necessary to configure the Dependency-Track Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy Dependency-Track to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -177,4 +177,5 @@ After completing these steps, Dependency-Track is configured to use Microsoft En
 
 ## Related Articles
 
+* [DefectDojo SSO guide](./defectdojo-oidc-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/grafana-authentication.md
+++ b/docs/operator-guide/microsoft-entra/grafana-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Grafana"
-description: "Step-by-step guide on configuring Grafana with OpenID Connect authentication using Microsoft Entra as the Identity Provider for enhanced access management."
+title: "Grafana Microsoft Entra OIDC SSO Setup"
+description: "Set up Grafana SSO with Microsoft Entra OIDC: step-by-step app registration and Helm chart configuration guide."
 sidebar_label: "Grafana"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Grafana"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/grafana-authentication" />
 </head>
 
-This guide provides instructions on configuring OpenID Connect (OIDC) authentication with Microsoft Entra for Grafana.
+Set up Grafana single sign-on with Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping Entra groups to Grafana roles, and updating the Grafana Helm chart — the same Microsoft Entra pattern used across [Nexus](./nexus-authentication.md), [DefectDojo](./defectdojo-oidc-authentication.md), and other KubeRocketCI add-ons.
 
-## Prerequisites
+## Prerequisites for Grafana SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Grafana Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Grafana, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -97,7 +97,7 @@ To manage access to Grafana, it is necessary to create the groups in Microsoft E
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring Grafana Helm chart
+## Configuring the Grafana Helm Chart for OIDC
 
 To integrate Grafana with configured Microsoft Entra Application, it is necessary to configure the Grafana Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository and the **prometheus-operator** Helm chart to deploy Grafana to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -206,4 +206,6 @@ After completing these steps, Grafana will be configured to use Microsoft Entra 
 
 ## Related Articles
 
+* [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md)
+* [DefectDojo Microsoft Entra OIDC SSO Setup](./defectdojo-oidc-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/harbor-authentication.md
+++ b/docs/operator-guide/microsoft-entra/harbor-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Harbor"
-description: "Step-by-step guide on configuring Harbor with OIDC authentication using Microsoft Entra as the Identity Provider for secure and streamlined access."
+title: "Harbor Microsoft Entra OIDC SSO Setup"
+description: "Configure Harbor registry SSO with Microsoft Entra OIDC: app registration and Helm chart configuration for secure container registry access."
 sidebar_label: "Harbor"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Harbor"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/harbor-authentication" />
 </head>
 
-This guide provides instructions on how to configure Harbor with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure Harbor single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping an Entra group to the Harbor OIDC Admin Group, and entering the resulting OIDC parameters directly in the Harbor UI — the same registry-access pattern used for [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md).
 
-## Prerequisites
+## Prerequisites for Harbor SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -23,7 +23,7 @@ Before you begin, make sure the following prerequisites are met:
 - [Microsoft Entra](https://learn.microsoft.com/en-us/entra/fundamentals/create-new-tenant) Tenant is created.
 - [Harbor](../artifacts-management/harbor-installation.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Harbor Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Harbor, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -125,4 +125,5 @@ After completing these steps, Harbor is configured to use Microsoft Entra as the
 
 ## Related Articles
 
+* [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/nexus-authentication.md
+++ b/docs/operator-guide/microsoft-entra/nexus-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Nexus"
-description: "Instructions on configuring Nexus with OIDC authentication using Microsoft Entra as the Identity Provider, including OAuth2-proxy setup for secure access."
+title: "Nexus SSO With Microsoft Entra OIDC"
+description: "Configure Nexus Repository SSO via Microsoft Entra OIDC and OAuth2-Proxy: app registration, groups, and Helm chart setup guide."
 sidebar_label: "Nexus"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Nexus"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/nexus-authentication" />
 </head>
 
-This guide provides instructions on how to configure Nexus with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP) and OAuth2-proxy as an authentication proxy.
+Configure single sign-on for Nexus Repository using Microsoft Entra as the OIDC provider and [OAuth2-Proxy](./oauth2-proxy-authentication.md) as the authentication front end. This guide covers Microsoft Entra app registration, Entra group mapping, and the combined Nexus + OAuth2-Proxy Helm chart configuration, followed by user provisioning through the Nexus Operator.
 
-## Prerequisites
+## Prerequisites for Nexus SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -26,7 +26,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Nexus Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Nexus, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -92,7 +92,7 @@ To manage access to Nexus using OAuth2-proxy, it is necessary to create groups i
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring Nexus and OAuth2-proxy Helm charts
+## Configuring Nexus and OAuth2-Proxy Helm Charts
 
 To integrate Nexus with the configured Microsoft Entra Application, it is necessary to configure the Nexus and OAuth2-proxy Helm charts. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy Nexus and OAuth2-proxy to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -183,7 +183,7 @@ To integrate Nexus with the configured Microsoft Entra Application, it is necess
 
 3. After updating the `values.yaml` file and creating the `oauth2-proxy` secret, commit the changes to the repository and apply the changes with Helm or Argo CD.
 
-## Creating the Nexus users with Nexus Operator
+## Creating Nexus Users with the Nexus Operator
 
 :::note
 Nexus users can also be created directly from the Nexus UI instead of using the Nexus Operator Helm chart.
@@ -230,4 +230,5 @@ After completing these steps, Nexus will be configured with OIDC authentication 
 
 ## Related Articles
 
+* [OAuth2-Proxy configuration for Microsoft Entra SSO](./oauth2-proxy-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/oauth2-proxy-authentication.md
+++ b/docs/operator-guide/microsoft-entra/oauth2-proxy-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With OAuth2-proxy (Tekton Dashboard)"
-description: "Instructions on configuring OAuth2-proxy for Tekton Dashboard with OIDC authentication using Microsoft Entra as the Identity Provider."
+title: "OAuth2-Proxy Microsoft Entra OIDC SSO Setup"
+description: "Configure OAuth2-Proxy for Tekton Dashboard with Microsoft Entra OIDC SSO: app registration, group mapping, and Helm chart setup steps."
 sidebar_label: "OAuth2-proxy (Tekton Dashboard)"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "OAuth2-proxy (Tekton Dashboard)"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/oauth2-proxy-authentication" />
 </head>
 
-This guide provides instructions on how to configure OAuth2-proxy for the Tekton Dashboard with OIDC authentication using Microsoft Entra as the Identity Provider.
+Configure OAuth2-Proxy to enforce Microsoft Entra OIDC single sign-on for the Tekton Dashboard. This guide covers registering the app in Microsoft Entra, mapping Entra groups to dashboard access, and deploying the OAuth2-Proxy Helm chart. It also applies if you're securing Nexus, which uses OAuth2-Proxy as its authentication front end — see the [Nexus SSO guide](./nexus-authentication.md).
 
-## Prerequisites
+## Prerequisites for OAuth2-Proxy SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -26,7 +26,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the OAuth2-Proxy Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for the OAuth2-proxy, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -75,7 +75,7 @@ To configure Microsoft Entra as the Identity Provider for the OAuth2-proxy, it i
 
 After the application is configured, you can proceed with the OAuth2-proxy Helm chart configuration.
 
-## Creating the Groups
+## Mapping Microsoft Entra Groups to OAuth2-Proxy Access
 
 To manage access to the Tekton Dashboard (or any other application with OAuth2-proxy), it is necessary to create groups in the Microsoft Entra Admin Center and assign users to it.
 
@@ -89,7 +89,7 @@ To manage access to the Tekton Dashboard (or any other application with OAuth2-p
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring OAuth2-proxy Helm chart
+## Deploying the OAuth2-Proxy Helm Chart for Tekton Dashboard
 
 To integrate OAuth2-proxy with the configured Microsoft Entra Application, it is necessary to configure the OAuth2-proxy Helm chart.
 
@@ -216,4 +216,5 @@ After completing these steps, the Tekton Dashboard will be configured to use OAu
 
 ## Related Articles
 
+* [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/oidc-authentication-overview.md
+++ b/docs/operator-guide/microsoft-entra/oidc-authentication-overview.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Microsoft Entra OIDC Authentication: Overview"
-description: "Overview of integrating Microsoft Entra as the Identity Provider for secure and seamless authentication across various components using OIDC protocol."
+title: "Microsoft Entra OIDC SSO Guides"
+description: "All Microsoft Entra OIDC SSO integration guides for KubeRocketCI: Argo CD, Grafana, Nexus, DefectDojo, Dependency-Track, and more."
 sidebar_label: "Overview"
 
 ---
@@ -21,16 +21,30 @@ Configuring OIDC authentication with Microsoft Entra brings significant benefits
 
 ## Supported Components
 
-Below is the list of components with OIDC integration instructions:
+Below is the list of components with OIDC integration instructions, grouped by function.
 
-- [Ansible AWX](awx-operator-authentication.md)
-- [Argo CD](argo-cd-authentication.md)
-- [AWS EKS and KubeRocketCI Portal](aws-eks-portal-authentication.md)
-- [Dependency-Track](./dependency-track-authentication.md)
+### Security & DevSecOps Tools
+
+Secure vulnerability-management and code-quality platforms with centralized Microsoft Entra sign-in.
+
 - [DefectDojo](defectdojo-oidc-authentication.md)
-- [Grafana](grafana-authentication.md)
-- [Harbor](harbor-authentication.md)
-- [Nexus](./nexus-authentication.md)
-- [OAuth2-proxy](oauth2-proxy-authentication.md)
-- [OpenSearch](opensearch-authentication.md)
+- [Dependency-Track](./dependency-track-authentication.md)
 - [SonarQube](./sonar-oidc-authentication.md)
+
+### Artifact & Registry Tools
+
+Control access to artifact repositories and image registries through Microsoft Entra groups.
+
+- [Nexus](./nexus-authentication.md)
+- [Harbor](harbor-authentication.md)
+
+### Platform & Observability Tools
+
+Bring platform, deployment, and monitoring tools under the same Microsoft Entra identity provider.
+
+- [Argo CD](argo-cd-authentication.md)
+- [Grafana](grafana-authentication.md)
+- [OpenSearch](opensearch-authentication.md)
+- [Ansible AWX](awx-operator-authentication.md)
+- [OAuth2-proxy](oauth2-proxy-authentication.md)
+- [AWS EKS and KubeRocketCI Portal](aws-eks-portal-authentication.md)

--- a/docs/operator-guide/microsoft-entra/opensearch-authentication.md
+++ b/docs/operator-guide/microsoft-entra/opensearch-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With OpenSearch"
-description: "Step-by-step guide on configuring OpenSearch with OIDC authentication using Microsoft Entra as the Identity Provider for enhanced security."
+title: "OpenSearch Microsoft Entra OIDC SSO Setup"
+description: "Configure OpenSearch SSO with Microsoft Entra OIDC: app registration, group-to-role mapping, and Helm chart setup for dashboards and cluster access."
 sidebar_label: "OpenSearch"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "OpenSearch"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/opensearch-authentication" />
 </head>
 
-This guide provides instructions on how to configure OpenSearch with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure OpenSearch single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping Entra groups to OpenSearch security roles, and updating the OpenSearch and OpenSearch Dashboards Helm chart values — an observability-stack setup that pairs naturally with [Grafana Microsoft Entra OIDC SSO](./grafana-authentication.md).
 
-## Prerequisites
+## Prerequisites for OpenSearch SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the OpenSearch Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for OpenSearch, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -92,7 +92,7 @@ To manage access to OpenSearch, it is necessary to create the groups in Microsof
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring OpenSearch Helm chart
+## Configuring the OpenSearch Helm Chart for OIDC
 
 To integrate OpenSearch with configured Microsoft Entra Application, it is necessary to configure the OpenSearch Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy OpenSearch to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -249,4 +249,6 @@ After completing these steps, OpenSearch will be configured with OIDC authentica
 
 ## Related Articles
 
+* [Grafana Microsoft Entra OIDC SSO Setup](./grafana-authentication.md)
+* [Ansible AWX Microsoft Entra OIDC SSO](./awx-operator-authentication.md)
 * [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/microsoft-entra/sonar-oidc-authentication.md
+++ b/docs/operator-guide/microsoft-entra/sonar-oidc-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With SonarQube"
-description: "Learn how to configure SonarQube with OIDC authentication using Microsoft Entra as the Identity Provider for secure and centralized access management."
+title: "SonarQube Microsoft Entra OIDC SSO Setup"
+description: "Configure SonarQube SSO with Microsoft Entra OIDC: app registration, group sync, and Sonar-Operator Helm chart configuration guide."
 sidebar_label: "SonarQube"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "SonarQube"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/sonar-oidc-authentication" />
 </head>
 
-This guide provides instructions on how to configure SonarQube with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure SonarQube single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, syncing Entra groups into SonarQube by Object ID, and configuring OIDC through the [edp-sonar-operator](https://github.com/epam/edp-sonar-operator) Helm chart — a quality-gate setup that fits alongside [DefectDojo](./defectdojo-oidc-authentication.md) and [Dependency-Track](./dependency-track-authentication.md) in a DevSecOps pipeline.
 
-## Prerequisites
+## Prerequisites for SonarQube SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -24,7 +24,7 @@ Before you begin, make sure the following prerequisites are met:
 - [SonarQube](../code-quality/sonarqube.md) is installed.
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 
-## Configuring Microsoft Entra Application
+## Registering the SonarQube Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for SonarQube, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -163,6 +163,17 @@ In this section, we will demonstrate how to set up OIDC authentication for Sonar
 
 After completing these steps, SonarQube will be configured with OIDC authentication using Microsoft Entra as the Identity Provider. Users will be able to log in to SonarQube using their Microsoft Entra credentials.
 
+## Troubleshooting SonarQube SSO with Microsoft Entra
+
+If the login flow fails after completing the steps above, check the following common causes:
+
+- **Error `AADSTS50011` (redirect URI mismatch) after clicking Log in with OpenID Connect.** The Redirect URI registered in the Microsoft Entra Application must exactly match the format shown in the registration step above, including the scheme and callback path. Update the application registration and retry.
+- **Login succeeds, but the user has no expected permissions.** Group synchronization did not match. Verify that the **groups claim** is added in the **Token configuration** section with the **Group ID** type, that the SonarQube group corresponds to the value emitted in the token as described in the groups section above, and that the user is a member of the Microsoft Entra group.
+- **Authentication fails immediately after redirect back to SonarQube.** The client secret has expired or the secret **Secret ID** was copied instead of the secret **Value**. Generate a new client secret in **Certificates & secrets** and update the SonarQube configuration.
+- **The Log in with OpenID Connect button is missing.** The OIDC configuration was not applied. Confirm the updated values were committed and deployed, and that the SonarQube pod restarted after the change.
+
 ## Related Articles
 
+* [DefectDojo Microsoft Entra OIDC SSO Setup](./defectdojo-oidc-authentication.md)
+* [Dependency-Track Microsoft Entra OIDC SSO](./dependency-track-authentication.md)
 * [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/docs/operator-guide/project-management-and-reporting/reportportal-keycloak.md
+++ b/docs/operator-guide/project-management-and-reporting/reportportal-keycloak.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Integrating ReportPortal with Keycloak: A Step-by-Step Guide"
-description: "Comprehensive guide on integrating ReportPortal with Keycloak for SAML-based authentication, including detailed steps for Keycloak configuration and ReportPortal setup."
+title: "ReportPortal SSO with Keycloak (SAML)"
+description: "Configure ReportPortal single sign-on with Keycloak via SAML: Keycloak client setup and ReportPortal authentication configuration, step by step."
 sidebar_label: "ReportPortal Keycloak Integration"
 
 ---
@@ -13,7 +13,7 @@ sidebar_label: "ReportPortal Keycloak Integration"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/project-management-and-reporting/reportportal-keycloak" />
 </head>
 
-Follow the steps below to integrate the ReportPortal with Keycloak.
+Configure single sign-on for ReportPortal using Keycloak as the SAML identity provider. This guide covers creating the Keycloak SAML client and enabling the integration on the ReportPortal side.
 
 :::info
   It is also possible to install ReportPortal using the cluster add-ons. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
@@ -95,3 +95,4 @@ To apply the Keycloak configuration, the Keycloak Operator is required. For inst
 
 * [Install ReportPortal](../project-management-and-reporting/install-reportportal.md)
 * [Integration With Tekton](reportportal-tekton.md)
+* [Install Keycloak](../auth/keycloak.md)

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -129,13 +129,6 @@ const config: Config = {
           {
             tagName: 'script',
             attributes: {
-              src: 'https://www.googletagmanager.com/gtm.js?id=GTM-527T2HLF',
-              async: 'true',
-            },
-          },
-          {
-            tagName: 'script',
-            attributes: {
               type: 'text/javascript',
             },
             innerHTML: 'window.dataLayer=window.dataLayer||[]',
@@ -201,20 +194,18 @@ const config: Config = {
           lastmod: 'date',
           changefreq: 'weekly',
           priority: 0.5,
-          ignorePatterns: [
-            '/docs/next/**',
-            '/docs/3.11/**',
-            '/docs/3.12/**',
-            '/blog/tags/**',
-            '/blog/authors/**',
-            '/search',
-          ],
+          ignorePatterns: ['/blog/tags/**', '/blog/authors/**', '/search'],
           filename: 'sitemap.xml',
           createSitemapItems: async params => {
             const { defaultCreateSitemapItems, ...rest } = params;
             const items = await defaultCreateSitemapItems(rest);
             return items
               .filter(item => !item.url.includes('/page/'))
+              // Versioned/next docs (e.g. /docs/3.13/..., /docs/next/...) always
+              // canonicalize to the unversioned latest URL, so they must never
+              // ship in the sitemap. Version-agnostic so this never drifts again
+              // when a new version is cut or an old one is dropped.
+              .filter(item => !/\/docs\/(next|\d+\.\d+)\//.test(item.url))
               .map(item => {
                 if (item.url === 'https://docs.kuberocketci.io/') {
                   return { ...item, priority: 1.0, changefreq: 'weekly' };
@@ -395,6 +386,11 @@ const config: Config = {
           label: 'GitHub',
           position: 'right',
         },
+        {
+          href: 'https://kuberocketci.io',
+          label: 'Main Site',
+          position: 'right',
+        },
       ],
     },
 
@@ -423,6 +419,19 @@ const config: Config = {
             {
               label: 'API Reference: Use KubeRocketCI To Build Your Solutions',
               to: '/docs/api/overview',
+            },
+          ],
+        },
+        {
+          title: 'Get Started',
+          items: [
+            {
+              label: 'Main Site',
+              href: 'https://kuberocketci.io',
+            },
+            {
+              label: 'Pricing',
+              href: 'https://kuberocketci.io/pricing',
             },
           ],
         },

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -135,6 +135,7 @@ const sidebars: SidebarsConfig = {
             'operator-guide/auth/keycloak',
             'operator-guide/auth/ui-portal-oidc',
             'operator-guide/auth/configure-keycloak-oidc-eks',
+            'operator-guide/auth/eks-oidc-integration',
             'operator-guide/auth/krci-cli-client-for-keycloak',
             'operator-guide/auth/oauth2-proxy',
             'operator-guide/auth/namespace-management',

--- a/versioned_docs/version-3.14/operator-guide/auth/configure-keycloak-oidc-eks.md
+++ b/versioned_docs/version-3.14/operator-guide/auth/configure-keycloak-oidc-eks.md
@@ -1,6 +1,6 @@
 ---
-title: "EKS OIDC With Keycloak"
-description: "Step-by-step guide on configuring Keycloak as OIDC Identity Provider for EKS, enabling Single Sign-On capabilities for enhanced security."
+title: "Keycloak as OIDC Provider for AWS EKS"
+description: "Configure Keycloak as the OIDC provider for AWS EKS: create clients and groups, associate the provider, and map RBAC roles for SSO kubectl access."
 sidebar_label: "EKS OIDC With Keycloak"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -14,26 +14,31 @@ import TabItem from '@theme/TabItem';
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/auth/configure-keycloak-oidc-eks" />
 </head>
 
-This article provides the instruction of configuring Keycloak as [OIDC Identity Provider](https://aws.amazon.com/blogs/containers/introducing-oidc-identity-provider-authentication-amazon-eks/) for EKS.
-The example is implemented following the KubeRocketCI add-ons approach.
+Configure Keycloak as the OIDC identity provider for an AWS EKS cluster so users can log in to `kubectl` with their existing Keycloak/SSO credentials instead of static IAM users. This guide walks through creating the Keycloak client and groups, associating Keycloak as an EKS OIDC provider (via Terraform or the AWS Console), and mapping Keycloak groups to Kubernetes RBAC roles — following the KubeRocketCI add-ons approach.
+
+For provisioning the underlying Keycloak realm/client/group resources through the Keycloak operator's Custom Resources, see [Provision Keycloak Resources for EKS OIDC](eks-oidc-integration.md).
 
 ## Prerequisites
 
-To follow the instruction, check the following prerequisites:
+### Required
 
-1. (Optional) Terraform version 1.5.7
-2. Kubelogin version >= v1.25.1
-3. (Optional) [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied
-4. (Optional) [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets)
-5. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak)
-6. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed
-7. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible
+1. The [kubelogin](https://github.com/int128/kubelogin) plugin, installed and configured to connect OIDC with a cluster. For Windows, it is recommended to download the kubelogin as a binary and add it to your PATH. Use the [latest kubelogin release](https://github.com/int128/kubelogin/releases).
+2. A running [Keycloak instance](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak).
+3. The [Keycloak operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/keycloak-operator) is deployed.
+4. The Keycloak Realm's OIDC discovery URL and jwks_uri endpoints are publicly accessible.
 
-:::note
-  To connect OIDC with a cluster, install and configure the [kubelogin](https://github.com/int128/kubelogin) plugin. For Windows, it is recommended to download the kubelogin as a binary and add it to your PATH.
-:::
+<details>
+<summary>Optional prerequisites</summary>
+
+- A recent Terraform 1.x release, if associating the EKS OIDC provider via Terraform instead of the AWS Console.
+- [EDP Cluster Add-ons](../add-ons-overview.md) Solution is applied.
+- [External Secrets Operator](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/external-secrets), if managing Keycloak credentials as synced secrets rather than manually.
+
+</details>
 
 ## Solution Overview
+
+By the end of this guide, Keycloak groups will be mapped to Kubernetes RBAC roles, letting users authenticate to the EKS cluster with `kubectl` using their Keycloak credentials instead of static IAM users.
 
 This architecture encompasses three primary resource types: AWS (EKS), Keycloak, and Kubernetes.
 Within this setup, the Keycloak resources, once established, remain static, facilitating the assignment of claims based on user group memberships. This stability contrasts with the dynamic nature of other resources, which may be created, modified, or deleted as necessary.
@@ -105,7 +110,7 @@ The initial step involves setting up the Keycloak operator (configure connection
     ```
 
 
-This add-ons facilitates sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including to EKS, Sonar, Nexus, and Portal.
+This add-on sets up a broker realm to manage traffic redirection between external Identity Providers (IdP) and internal clients. Additionally, it creates a shared realm that encompasses all clients, including EKS, Sonar, Nexus, and Portal.
 
 The [KubeRocketCI RBAC add-on](https://github.com/epam/edp-cluster-add-ons/tree/main/clusters/core/addons/kuberocketci-rbac) creates Keycloak groups that are used in the KubeRocketCI platform to manage access to resources. For more details refer to the [KubeRocketCI Groups](platform-auth-model.md#groups) documentation.
 
@@ -289,6 +294,9 @@ To access the Kubernetes cluster via [Lens](https://k8slens.dev/), follow the st
 
 By default, the Keycloak token has a lifespan of 5 minutes. To modify this duration refer to the guidelines outlined in this [document](ui-portal-oidc.md#changing-the-lifespan-of-an-access-token).
 
+For application-level OIDC via OAuth2-Proxy rather than cluster `kubectl` access, see [Tekton Dashboard Authentication](./oauth2-proxy.md). Using Microsoft Entra instead of Keycloak? See [AWS EKS OIDC With Microsoft Entra](../microsoft-entra/aws-eks-portal-authentication.md).
+
 ## Related Articles
 
 * [Headlamp OIDC Configuration](ui-portal-oidc.md)
+* [Provision Keycloak Resources for EKS OIDC](eks-oidc-integration.md)

--- a/versioned_docs/version-3.14/operator-guide/auth/eks-oidc-integration.md
+++ b/versioned_docs/version-3.14/operator-guide/auth/eks-oidc-integration.md
@@ -1,6 +1,6 @@
 ---
-title: "AWS EKS OIDC Integration"
-description: "Comprehensive guide on integrating Keycloak with AWS EKS for OIDC authentication, enhancing security with Single Sign-On capabilities."
+title: "Provision Keycloak Resources for EKS OIDC"
+description: "Provision Keycloak realm, client, and group resources for AWS EKS OIDC through the edp-keycloak-operator Custom Resources, installed via Helm."
 sidebar_label: "AWS EKS OIDC Integration"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -11,12 +11,12 @@ sidebar_label: "AWS EKS OIDC Integration"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/auth/eks-oidc-integration" />
 </head>
 
-This page serves as a comprehensive guide on integrating Keycloak with the [edp-keycloak-operator](https://github.com/epam/edp-keycloak-operator) to act as an identity provider for AWS Elastic Kubernetes Service (EKS). It provides detailed step-by-step instructions for creating the necessary realms, users, roles, and client configurations to seamlessly collaborate between Keycloak and EKS. Additionally, it includes instructions on installing the edp-keycloak-operator using Helm charts.
+This page shows how to provision the Keycloak realm, client, group, and user resources needed for EKS OIDC by installing the [edp-keycloak-operator](https://github.com/epam/edp-keycloak-operator) via Helm and applying its Custom Resources — `Keycloak`, `KeycloakRealm`, `KeycloakRealmGroup`, `KeycloakClientScope`, `KeycloakClient`, and `KeycloakRealmUser`. It covers only the Keycloak-side resource provisioning; for the end-to-end setup of EKS cluster access — associating Keycloak as the EKS OIDC provider and mapping groups to Kubernetes RBAC roles — see [Keycloak as OIDC Provider for AWS EKS](./configure-keycloak-oidc-eks.md).
 
 ## Prerequisites
 
 - [EKS Configuration](./configure-keycloak-oidc-eks.md) is performed
-- [Helm v3.10.0](https://github.com/helm/helm/releases/tag/v3.10.0) is installed
+- A recent Helm 3.x release is installed
 - [Keycloak](../../operator-guide/auth/keycloak.md) is installed
 
 ## Install Keycloak Operator

--- a/versioned_docs/version-3.14/operator-guide/auth/keycloak.md
+++ b/versioned_docs/version-3.14/operator-guide/auth/keycloak.md
@@ -1,6 +1,6 @@
 ---
 title: "Install Keycloak"
-description: "Comprehensive guide on installing Keycloak within KubeRocketCI for robust identity and access management, including prerequisites and configuration steps."
+description: "Install Keycloak on Kubernetes and configure it with the EDP Keycloak Operator: PostgreSQL setup, Helm installation, and operator-managed realms."
 sidebar_label: "Install Keycloak"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -356,7 +356,7 @@ To install Keycloak, follow the steps below:
 
     </details>
 
-## Configuration
+## Configure Keycloak with the EDP Keycloak Operator {#configuration}
 
 For configuring Keycloak within your environment, it's recommended to utilize the [edp-keycloak-operator](https://github.com/epam/edp-keycloak-operator).
 This operator simplifies the integration process by automating the deployment and management of Keycloak instances.

--- a/versioned_docs/version-3.14/operator-guide/devsecops/defectdojo.md
+++ b/versioned_docs/version-3.14/operator-guide/devsecops/defectdojo.md
@@ -1,6 +1,6 @@
 ---
-title: "Integrate DefectDojo"
-description: "Guide on integrating DefectDojo with KubeRocketCI for vulnerability management, including installation steps and configuring DefectDojo for CI/CD integration."
+title: "Install and Integrate DefectDojo"
+description: "Install DefectDojo on Kubernetes with Helm and integrate it with KubeRocketCI pipelines: step-by-step setup for CI/CD vulnerability management."
 sidebar_label: "Integrate DefectDojo"
 ---
 <!-- markdownlint-disable MD025 -->
@@ -14,7 +14,7 @@ import TabItem from '@theme/TabItem';
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/devsecops/defectdojo" />
 </head>
 
-Inspect the main steps to perform for installing DefectDojo via Helm Chart.
+Install DefectDojo on Kubernetes with Helm and integrate it into KubeRocketCI pipelines for vulnerability management. Once installed, you can enable single sign-on by following the [DefectDojo Microsoft Entra OIDC SSO Setup](../microsoft-entra/defectdojo-oidc-authentication.md) guide.
 
 :::info
   It is also possible to install DefectDojo using the add-ons approach. For details, please refer to the [KubeRocketCI addons approach](https://github.com/epam/edp-cluster-add-ons).
@@ -332,3 +332,4 @@ After following the instructions provided, you should be able to integrate your 
 * [Install External Secrets Operator](../secrets-management/install-external-secrets-operator.md)
 * [External Secrets Operator Integration](../secrets-management/external-secrets-operator-integration.md)
 * [Install Harbor](../artifacts-management/harbor-installation.md)
+* [DefectDojo Microsoft Entra OIDC SSO Setup](../microsoft-entra/defectdojo-oidc-authentication.md)

--- a/versioned_docs/version-3.14/operator-guide/devsecops/dependency-track.md
+++ b/versioned_docs/version-3.14/operator-guide/devsecops/dependency-track.md
@@ -107,3 +107,4 @@ After following the instructions provided, you should be able to integrate your 
 * [Install External Secrets Operator](../secrets-management/install-external-secrets-operator.md)
 * [External Secrets Operator Integration](../secrets-management/external-secrets-operator-integration.md)
 * [Cluster Add-Ons Overview](../add-ons-overview.md)
+* [Dependency-Track Microsoft Entra OIDC SSO](../microsoft-entra/dependency-track-authentication.md)

--- a/versioned_docs/version-3.14/operator-guide/infrastructure-providers/aws/ebs-csi-driver.md
+++ b/versioned_docs/version-3.14/operator-guide/infrastructure-providers/aws/ebs-csi-driver.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Amazon EBS CSI Driver"
-description: "Enable Amazon EKS clusters to manage Amazon EBS volumes with the EBS CSI driver, covering prerequisites, IAM setup, and add-on installation."
+title: "AWS EBS CSI Driver Setup for EKS"
+description: "Step-by-step guide to setting up the AWS EBS CSI driver on Amazon EKS: IAM OIDC prerequisites, trust policy, IAM role, and add-on install."
 sidebar_label: "Amazon EBS CSI Driver"
 
 ---
@@ -13,7 +13,7 @@ sidebar_label: "Amazon EBS CSI Driver"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/infrastructure-providers/aws/ebs-csi-driver" />
 </head>
 
-The Amazon Elastic Block Store (Amazon EBS) Container Storage Interface (CSI) driver allows Amazon Elastic Kubernetes Service (Amazon EKS) clusters to manage the lifecycle of Amazon EBS volumes for Kubernetes Persistent Volumes.
+This guide shows how to install the AWS EBS CSI driver on an Amazon EKS cluster, step by step: creating the IAM OIDC trust policy, attaching the AWS-managed IAM policy, and deploying the driver as an EKS add-on so Kubernetes can manage Amazon EBS-backed Persistent Volumes.
 
 ## Prerequisites
 

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/argo-cd-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/argo-cd-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Argo CD"
-description: "Learn how to configure OIDC authentication for Argo CD using Microsoft Entra as the Identity Provider, ensuring secure and efficient access management."
+title: "Argo CD Microsoft Entra OIDC SSO Setup"
+description: "Configure Argo CD SSO with Microsoft Entra OIDC: app registration, group-to-role mapping, and Helm chart configuration guide."
 sidebar_label: "Argo CD"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Argo CD"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/argo-cd-authentication" />
 </head>
 
-This guide provides instructions on how to configure OIDC authentication for the Argo CD using Microsoft Entra as the Identity Provider.
+Configure Argo CD single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping Entra groups to Argo CD RBAC roles, and updating the Argo CD Helm chart — the same platform-access pattern used for the [AWS EKS cluster and KubeRocketCI Portal](./aws-eks-portal-authentication.md).
 
-## Prerequisites
+## Prerequisites for Argo CD SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Argo CD Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for the Argo CD, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -94,7 +94,7 @@ To manage access to the Argo CD, it is necessary to create groups in the Microso
 
 3. Click on the **Create** button and repeat this process for each required group.
 
-## Configuring Argo CD Helm chart
+## Configuring the Argo CD Helm Chart for OIDC
 
 To integrate Argo CD with configured Microsoft Entra Application, it is necessary to configure the Argo CD Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy Argo CD to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -193,6 +193,19 @@ The **Object ID** can be found in the **Overview** section of the group in the M
 
 After completing these steps, the Argo CD will be configured to use Microsoft Entra as the Identity Provider for authentication. Users will be able to log in to the Argo CD using their Microsoft Entra credentials.
 
+## Troubleshooting Argo CD SSO with Microsoft Entra
+
+If the login flow fails after completing the steps above, check the following common causes:
+
+- **Error `AADSTS50011` (redirect URI mismatch) after clicking Log in via Entra.** The Redirect URI registered in the **Authentication** section of the Microsoft Entra Application must exactly match `https://<Argo CD URL>/auth/callback`, including the scheme and any trailing path. Update the application registration and retry.
+- **Login succeeds, but the user sees no applications or projects.** Argo CD RBAC did not match any group. Verify that the **groups claim** is added in the **Token configuration** section with the **Group ID** type, that the group **Object ID** used in the Argo CD RBAC policy matches the group in Microsoft Entra, and that `scopes` in the Helm values includes `groups`.
+- **`invalid client credentials` or an endless login loop.** The client secret has expired or the secret **Secret ID** was copied instead of the secret **Value**. Generate a new client secret in **Certificates & secrets** and update the secret referenced by the Argo CD Helm chart.
+- **The groups claim is missing for some users.** When a user belongs to a large number of groups, Microsoft Entra replaces the group list in the token with an overage claim, and Argo CD cannot evaluate it. Use dedicated, smaller groups for Argo CD access.
+
+To inspect the exact OIDC error, check the `argocd-server` pod logs while reproducing the login attempt.
+
 ## Related Articles
 
+* [AWS EKS & KubeRocketCI Portal Microsoft Entra OIDC SSO](./aws-eks-portal-authentication.md)
+* [Grafana Microsoft Entra OIDC SSO Setup](./grafana-authentication.md)
 * [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/aws-eks-portal-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/aws-eks-portal-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With AWS EKS & KubeRocketCI Portal"
-description: "Comprehensive instructions on configuring OIDC authentication for AWS EKS and KubeRocketCI Portal using Microsoft Entra, including default namespace and user picture configuration."
+title: "AWS EKS & Portal Microsoft Entra OIDC SSO"
+description: "Configure Microsoft Entra OIDC for AWS EKS and the KubeRocketCI Portal: default namespace and profile picture via Entra extension attributes."
 sidebar_label: "AWS EKS & KubeRocketCI Portal"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "AWS EKS & KubeRocketCI Portal"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/aws-eks-portal-authentication" />
 </head>
 
-This guide provides instructions on how to configure OpenID Connect (OIDC) authentication for the AWS EKS cluster and the KubeRocketCI Portal using Microsoft Entra as the Identity Provider (IdP), as well as how to configure the default namespace and user picture in the KubeRocketCI Portal using Microsoft Entra extension attributes.
+Configure Microsoft Entra as the OIDC identity provider for both the AWS EKS cluster and the KubeRocketCI Portal, then use Entra extension attributes to auto-populate each user's default namespace and profile picture on login. This platform-access setup pairs naturally with [Argo CD Microsoft Entra SSO](./argo-cd-authentication.md) for a single sign-on experience across the deployment stack.
 
-## Prerequisites
+## Prerequisites for AWS EKS & Portal SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -418,4 +418,5 @@ Follow the steps below to configure and assign a custom Token Lifetime Policy to
 
 ## Related Articles
 
+* [Argo CD Microsoft Entra OIDC SSO Setup](./argo-cd-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/awx-operator-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/awx-operator-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Ansible AWX"
-description: "Step-by-step instructions on configuring Ansible AWX with OIDC authentication using Microsoft Entra as the Identity Provider for enhanced security."
+title: "Ansible AWX Microsoft Entra OIDC SSO"
+description: "Configure Ansible AWX SSO with Microsoft Entra OIDC: app registration, client secret, and Azure AD authentication settings guide."
 sidebar_label: "Ansible AWX"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Ansible AWX"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/awx-operator-authentication" />
 </head>
 
-This guide provides instructions on how to configure Ansible AWX with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure Ansible AWX single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application and entering the resulting client credentials into the AWX Azure AD authentication settings — see the [Microsoft Entra OIDC overview](./oidc-authentication-overview.md) for the full list of KubeRocketCI add-ons that follow this same pattern.
 
-## Prerequisites
+## Prerequisites for Ansible AWX SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -23,7 +23,7 @@ Before you begin, make sure the following prerequisites are met:
 - [Microsoft Entra](https://learn.microsoft.com/en-us/entra/fundamentals/create-new-tenant) Tenant is created.
 - Ansible AWX is installed using the [AWX Operator](https://github.com/ansible-community/awx-operator-helm).
 
-## Configuring Microsoft Entra Application
+## Registering the Ansible AWX Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for the Ansible AWX, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -88,4 +88,5 @@ After completing these steps, the Ansible AWX will be configured to use OIDC aut
 
 ## Related Articles
 
+* [OpenSearch Microsoft Entra OIDC SSO Setup](./opensearch-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/defectdojo-oidc-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/defectdojo-oidc-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With DefectDojo"
-description: "Comprehensive guide on configuring DefectDojo with OIDC authentication using Microsoft Entra as the Identity Provider for secure access management."
+title: "DefectDojo Microsoft Entra OIDC SSO Setup"
+description: "Set up DefectDojo SSO with Microsoft Entra OIDC: app registration and Helm chart configuration for secure DevSecOps platform access."
 sidebar_label: "DefectDojo"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "DefectDojo"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/defectdojo-oidc-authentication" />
 </head>
 
-This guide provides instructions on how to configure DefectDojo with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Set up DefectDojo single sign-on using Microsoft Entra as the OIDC identity provider. This guide walks through registering the Microsoft Entra application, configuring redirect URIs, and updating the DefectDojo Helm chart so vulnerability-management access is centrally managed alongside the rest of your DevSecOps stack, including [Dependency-Track](./dependency-track-authentication.md).
 
-## Prerequisites
+## Prerequisites for DefectDojo SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the DefectDojo Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for DefectDojo, it is necessary to create and configure an Application in the Microsoft Entra Admin Center.
 
@@ -61,7 +61,7 @@ To configure Microsoft Entra as the Identity Provider for DefectDojo, it is nece
 
     ![API permissions](../../assets/operator-guide/microsoft-entra-auth/defectdojo-api-permissions.png)
 
-## Configuring DefectDojo Helm chart
+## Configuring the DefectDojo Helm Chart for OIDC
 
 To integrate DefectDojo with configured Microsoft Entra Application, it is necessary to configure the DefectDojo Helm chart.
 In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy DefectDojo to the Kubernetes (e.g. AWS EKS) cluster.
@@ -153,6 +153,7 @@ The Application data, such as **Application (client) ID** and **Directory (tenan
 
 6. After successfully verifying the login, you can proceed with configuring specific permissions for each logged-in user directly within the DefectDojo application.
 
-## Related articles
+## Related Articles
 
+- [Dependency-Track Microsoft Entra OIDC SSO](./dependency-track-authentication.md)
 - [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/dependency-track-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/dependency-track-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Dependency-Track"
-description: "Learn how to configure Dependency-Track with OIDC authentication using Microsoft Entra as the Identity Provider for secure and efficient access management."
+title: "Dependency-Track Microsoft Entra OIDC SSO"
+description: "Configure Dependency-Track SSO with Microsoft Entra OIDC: app registration and Helm chart setup for secure vulnerability-management access."
 sidebar_label: "Dependency-Track"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Dependency-Track"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/dependency-track-authentication" />
 </head>
 
-This guide provides instructions on how to configure Dependency-Track with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure Dependency-Track single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping access groups, and updating the Dependency-Track Helm chart — pairing naturally with [DefectDojo SSO](./defectdojo-oidc-authentication.md) if you run both scanners in your DevSecOps pipeline.
 
-## Prerequisites
+## Prerequisites for Dependency-Track SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - [Crunchy PostgreSQL Operator](https://github.com/CrunchyData/postgres-operator) is installed.
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 
-## Configuring Microsoft Entra Application
+## Registering the Dependency-Track Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Dependency-Track, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -86,7 +86,7 @@ To manage access to Dependency-Track, it is necessary to create the groups in Mi
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring Dependency-Track Helm chart
+## Configuring the Dependency-Track Helm Chart for OIDC
 
 To integrate Dependency-Track with configured Microsoft Entra Application, it is necessary to configure the Dependency-Track Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy Dependency-Track to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -177,4 +177,5 @@ After completing these steps, Dependency-Track is configured to use Microsoft En
 
 ## Related Articles
 
+* [DefectDojo SSO guide](./defectdojo-oidc-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/grafana-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/grafana-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Grafana"
-description: "Step-by-step guide on configuring Grafana with OpenID Connect authentication using Microsoft Entra as the Identity Provider for enhanced access management."
+title: "Grafana Microsoft Entra OIDC SSO Setup"
+description: "Set up Grafana SSO with Microsoft Entra OIDC: step-by-step app registration and Helm chart configuration guide."
 sidebar_label: "Grafana"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Grafana"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/grafana-authentication" />
 </head>
 
-This guide provides instructions on configuring OpenID Connect (OIDC) authentication with Microsoft Entra for Grafana.
+Set up Grafana single sign-on with Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping Entra groups to Grafana roles, and updating the Grafana Helm chart — the same Microsoft Entra pattern used across [Nexus](./nexus-authentication.md), [DefectDojo](./defectdojo-oidc-authentication.md), and other KubeRocketCI add-ons.
 
-## Prerequisites
+## Prerequisites for Grafana SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Grafana Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Grafana, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -97,7 +97,7 @@ To manage access to Grafana, it is necessary to create the groups in Microsoft E
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring Grafana Helm chart
+## Configuring the Grafana Helm Chart for OIDC
 
 To integrate Grafana with configured Microsoft Entra Application, it is necessary to configure the Grafana Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository and the **prometheus-operator** Helm chart to deploy Grafana to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -206,4 +206,6 @@ After completing these steps, Grafana will be configured to use Microsoft Entra 
 
 ## Related Articles
 
+* [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md)
+* [DefectDojo Microsoft Entra OIDC SSO Setup](./defectdojo-oidc-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/harbor-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/harbor-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Harbor"
-description: "Step-by-step guide on configuring Harbor with OIDC authentication using Microsoft Entra as the Identity Provider for secure and streamlined access."
+title: "Harbor Microsoft Entra OIDC SSO Setup"
+description: "Configure Harbor registry SSO with Microsoft Entra OIDC: app registration and Helm chart configuration for secure container registry access."
 sidebar_label: "Harbor"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Harbor"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/harbor-authentication" />
 </head>
 
-This guide provides instructions on how to configure Harbor with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure Harbor single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping an Entra group to the Harbor OIDC Admin Group, and entering the resulting OIDC parameters directly in the Harbor UI — the same registry-access pattern used for [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md).
 
-## Prerequisites
+## Prerequisites for Harbor SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -23,7 +23,7 @@ Before you begin, make sure the following prerequisites are met:
 - [Microsoft Entra](https://learn.microsoft.com/en-us/entra/fundamentals/create-new-tenant) Tenant is created.
 - [Harbor](../artifacts-management/harbor-installation.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Harbor Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Harbor, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -125,4 +125,5 @@ After completing these steps, Harbor is configured to use Microsoft Entra as the
 
 ## Related Articles
 
+* [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/nexus-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/nexus-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With Nexus"
-description: "Instructions on configuring Nexus with OIDC authentication using Microsoft Entra as the Identity Provider, including OAuth2-proxy setup for secure access."
+title: "Nexus SSO With Microsoft Entra OIDC"
+description: "Configure Nexus Repository SSO via Microsoft Entra OIDC and OAuth2-Proxy: app registration, groups, and Helm chart setup guide."
 sidebar_label: "Nexus"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "Nexus"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/nexus-authentication" />
 </head>
 
-This guide provides instructions on how to configure Nexus with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP) and OAuth2-proxy as an authentication proxy.
+Configure single sign-on for Nexus Repository using Microsoft Entra as the OIDC provider and [OAuth2-Proxy](./oauth2-proxy-authentication.md) as the authentication front end. This guide covers Microsoft Entra app registration, Entra group mapping, and the combined Nexus + OAuth2-Proxy Helm chart configuration, followed by user provisioning through the Nexus Operator.
 
-## Prerequisites
+## Prerequisites for Nexus SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -26,7 +26,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the Nexus Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for Nexus, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -92,7 +92,7 @@ To manage access to Nexus using OAuth2-proxy, it is necessary to create groups i
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring Nexus and OAuth2-proxy Helm charts
+## Configuring Nexus and OAuth2-Proxy Helm Charts
 
 To integrate Nexus with the configured Microsoft Entra Application, it is necessary to configure the Nexus and OAuth2-proxy Helm charts. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy Nexus and OAuth2-proxy to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -183,7 +183,7 @@ To integrate Nexus with the configured Microsoft Entra Application, it is necess
 
 3. After updating the `values.yaml` file and creating the `oauth2-proxy` secret, commit the changes to the repository and apply the changes with Helm or Argo CD.
 
-## Creating the Nexus users with Nexus Operator
+## Creating Nexus Users with the Nexus Operator
 
 :::note
 Nexus users can also be created directly from the Nexus UI instead of using the Nexus Operator Helm chart.
@@ -230,4 +230,5 @@ After completing these steps, Nexus will be configured with OIDC authentication 
 
 ## Related Articles
 
+* [OAuth2-Proxy configuration for Microsoft Entra SSO](./oauth2-proxy-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/oauth2-proxy-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/oauth2-proxy-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With OAuth2-proxy (Tekton Dashboard)"
-description: "Instructions on configuring OAuth2-proxy for Tekton Dashboard with OIDC authentication using Microsoft Entra as the Identity Provider."
+title: "OAuth2-Proxy Microsoft Entra OIDC SSO Setup"
+description: "Configure OAuth2-Proxy for Tekton Dashboard with Microsoft Entra OIDC SSO: app registration, group mapping, and Helm chart setup steps."
 sidebar_label: "OAuth2-proxy (Tekton Dashboard)"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "OAuth2-proxy (Tekton Dashboard)"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/oauth2-proxy-authentication" />
 </head>
 
-This guide provides instructions on how to configure OAuth2-proxy for the Tekton Dashboard with OIDC authentication using Microsoft Entra as the Identity Provider.
+Configure OAuth2-Proxy to enforce Microsoft Entra OIDC single sign-on for the Tekton Dashboard. This guide covers registering the app in Microsoft Entra, mapping Entra groups to dashboard access, and deploying the OAuth2-Proxy Helm chart. It also applies if you're securing Nexus, which uses OAuth2-Proxy as its authentication front end — see the [Nexus SSO guide](./nexus-authentication.md).
 
-## Prerequisites
+## Prerequisites for OAuth2-Proxy SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -26,7 +26,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the OAuth2-Proxy Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for the OAuth2-proxy, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -75,7 +75,7 @@ To configure Microsoft Entra as the Identity Provider for the OAuth2-proxy, it i
 
 After the application is configured, you can proceed with the OAuth2-proxy Helm chart configuration.
 
-## Creating the Groups
+## Mapping Microsoft Entra Groups to OAuth2-Proxy Access
 
 To manage access to the Tekton Dashboard (or any other application with OAuth2-proxy), it is necessary to create groups in the Microsoft Entra Admin Center and assign users to it.
 
@@ -89,7 +89,7 @@ To manage access to the Tekton Dashboard (or any other application with OAuth2-p
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring OAuth2-proxy Helm chart
+## Deploying the OAuth2-Proxy Helm Chart for Tekton Dashboard
 
 To integrate OAuth2-proxy with the configured Microsoft Entra Application, it is necessary to configure the OAuth2-proxy Helm chart.
 
@@ -216,4 +216,5 @@ After completing these steps, the Tekton Dashboard will be configured to use OAu
 
 ## Related Articles
 
+* [Nexus SSO with Microsoft Entra OIDC](./nexus-authentication.md)
 * [OpenID Connect (OIDC) Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/oidc-authentication-overview.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/oidc-authentication-overview.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Microsoft Entra OIDC Authentication: Overview"
-description: "Overview of integrating Microsoft Entra as the Identity Provider for secure and seamless authentication across various components using OIDC protocol."
+title: "Microsoft Entra OIDC SSO Guides"
+description: "All Microsoft Entra OIDC SSO integration guides for KubeRocketCI: Argo CD, Grafana, Nexus, DefectDojo, Dependency-Track, and more."
 sidebar_label: "Overview"
 
 ---
@@ -21,16 +21,30 @@ Configuring OIDC authentication with Microsoft Entra brings significant benefits
 
 ## Supported Components
 
-Below is the list of components with OIDC integration instructions:
+Below is the list of components with OIDC integration instructions, grouped by function.
 
-- [Ansible AWX](awx-operator-authentication.md)
-- [Argo CD](argo-cd-authentication.md)
-- [AWS EKS and KubeRocketCI Portal](aws-eks-portal-authentication.md)
-- [Dependency-Track](./dependency-track-authentication.md)
+### Security & DevSecOps Tools
+
+Secure vulnerability-management and code-quality platforms with centralized Microsoft Entra sign-in.
+
 - [DefectDojo](defectdojo-oidc-authentication.md)
-- [Grafana](grafana-authentication.md)
-- [Harbor](harbor-authentication.md)
-- [Nexus](./nexus-authentication.md)
-- [OAuth2-proxy](oauth2-proxy-authentication.md)
-- [OpenSearch](opensearch-authentication.md)
+- [Dependency-Track](./dependency-track-authentication.md)
 - [SonarQube](./sonar-oidc-authentication.md)
+
+### Artifact & Registry Tools
+
+Control access to artifact repositories and image registries through Microsoft Entra groups.
+
+- [Nexus](./nexus-authentication.md)
+- [Harbor](harbor-authentication.md)
+
+### Platform & Observability Tools
+
+Bring platform, deployment, and monitoring tools under the same Microsoft Entra identity provider.
+
+- [Argo CD](argo-cd-authentication.md)
+- [Grafana](grafana-authentication.md)
+- [OpenSearch](opensearch-authentication.md)
+- [Ansible AWX](awx-operator-authentication.md)
+- [OAuth2-proxy](oauth2-proxy-authentication.md)
+- [AWS EKS and KubeRocketCI Portal](aws-eks-portal-authentication.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/opensearch-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/opensearch-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With OpenSearch"
-description: "Step-by-step guide on configuring OpenSearch with OIDC authentication using Microsoft Entra as the Identity Provider for enhanced security."
+title: "OpenSearch Microsoft Entra OIDC SSO Setup"
+description: "Configure OpenSearch SSO with Microsoft Entra OIDC: app registration, group-to-role mapping, and Helm chart setup for dashboards and cluster access."
 sidebar_label: "OpenSearch"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "OpenSearch"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/opensearch-authentication" />
 </head>
 
-This guide provides instructions on how to configure OpenSearch with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure OpenSearch single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, mapping Entra groups to OpenSearch security roles, and updating the OpenSearch and OpenSearch Dashboards Helm chart values — an observability-stack setup that pairs naturally with [Grafana Microsoft Entra OIDC SSO](./grafana-authentication.md).
 
-## Prerequisites
+## Prerequisites for OpenSearch SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -25,7 +25,7 @@ Before you begin, make sure the following prerequisites are met:
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 - (Optional) [External Secrets Operator](../secrets-management/install-external-secrets-operator.md) is installed.
 
-## Configuring Microsoft Entra Application
+## Registering the OpenSearch Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for OpenSearch, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -92,7 +92,7 @@ To manage access to OpenSearch, it is necessary to create the groups in Microsof
 
 3. After adding the necessary members, review the group settings and click **Create** to save the group. Repeat this process for each required group.
 
-## Configuring OpenSearch Helm chart
+## Configuring the OpenSearch Helm Chart for OIDC
 
 To integrate OpenSearch with configured Microsoft Entra Application, it is necessary to configure the OpenSearch Helm chart. In this example, we will use the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository to deploy OpenSearch to the Kubernetes (e.g. AWS EKS) cluster.
 
@@ -249,4 +249,6 @@ After completing these steps, OpenSearch will be configured with OIDC authentica
 
 ## Related Articles
 
+* [Grafana Microsoft Entra OIDC SSO Setup](./grafana-authentication.md)
+* [Ansible AWX Microsoft Entra OIDC SSO](./awx-operator-authentication.md)
 * [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/microsoft-entra/sonar-oidc-authentication.md
+++ b/versioned_docs/version-3.14/operator-guide/microsoft-entra/sonar-oidc-authentication.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Guide: Microsoft Entra SSO Integration With SonarQube"
-description: "Learn how to configure SonarQube with OIDC authentication using Microsoft Entra as the Identity Provider for secure and centralized access management."
+title: "SonarQube Microsoft Entra OIDC SSO Setup"
+description: "Configure SonarQube SSO with Microsoft Entra OIDC: app registration, group sync, and Sonar-Operator Helm chart configuration guide."
 sidebar_label: "SonarQube"
 
 ---
@@ -13,9 +13,9 @@ sidebar_label: "SonarQube"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/microsoft-entra/sonar-oidc-authentication" />
 </head>
 
-This guide provides instructions on how to configure SonarQube with OpenID Connect (OIDC) authentication using Microsoft Entra as the Identity Provider (IdP).
+Configure SonarQube single sign-on using Microsoft Entra as the OIDC identity provider. This guide covers registering the Microsoft Entra application, syncing Entra groups into SonarQube by Object ID, and configuring OIDC through the [edp-sonar-operator](https://github.com/epam/edp-sonar-operator) Helm chart — a quality-gate setup that fits alongside [DefectDojo](./defectdojo-oidc-authentication.md) and [Dependency-Track](./dependency-track-authentication.md) in a DevSecOps pipeline.
 
-## Prerequisites
+## Prerequisites for SonarQube SSO with Microsoft Entra
 
 Before you begin, make sure the following prerequisites are met:
 
@@ -24,7 +24,7 @@ Before you begin, make sure the following prerequisites are met:
 - [SonarQube](../code-quality/sonarqube.md) is installed.
 - A forked copy of the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository is created.
 
-## Configuring Microsoft Entra Application
+## Registering the SonarQube Application in Microsoft Entra
 
 To configure Microsoft Entra as the Identity Provider for SonarQube, it is necessary to create and configure an Application in the Microsoft Entra Admin Center:
 
@@ -163,6 +163,17 @@ In this section, we will demonstrate how to set up OIDC authentication for Sonar
 
 After completing these steps, SonarQube will be configured with OIDC authentication using Microsoft Entra as the Identity Provider. Users will be able to log in to SonarQube using their Microsoft Entra credentials.
 
+## Troubleshooting SonarQube SSO with Microsoft Entra
+
+If the login flow fails after completing the steps above, check the following common causes:
+
+- **Error `AADSTS50011` (redirect URI mismatch) after clicking Log in with OpenID Connect.** The Redirect URI registered in the Microsoft Entra Application must exactly match the format shown in the registration step above, including the scheme and callback path. Update the application registration and retry.
+- **Login succeeds, but the user has no expected permissions.** Group synchronization did not match. Verify that the **groups claim** is added in the **Token configuration** section with the **Group ID** type, that the SonarQube group corresponds to the value emitted in the token as described in the groups section above, and that the user is a member of the Microsoft Entra group.
+- **Authentication fails immediately after redirect back to SonarQube.** The client secret has expired or the secret **Secret ID** was copied instead of the secret **Value**. Generate a new client secret in **Certificates & secrets** and update the SonarQube configuration.
+- **The Log in with OpenID Connect button is missing.** The OIDC configuration was not applied. Confirm the updated values were committed and deployed, and that the SonarQube pod restarted after the change.
+
 ## Related Articles
 
+* [DefectDojo Microsoft Entra OIDC SSO Setup](./defectdojo-oidc-authentication.md)
+* [Dependency-Track Microsoft Entra OIDC SSO](./dependency-track-authentication.md)
 * [OpenID Connect Authentication Overview](./oidc-authentication-overview.md)

--- a/versioned_docs/version-3.14/operator-guide/project-management-and-reporting/reportportal-keycloak.md
+++ b/versioned_docs/version-3.14/operator-guide/project-management-and-reporting/reportportal-keycloak.md
@@ -1,7 +1,7 @@
 ---
 
-title: "Integrating ReportPortal with Keycloak: A Step-by-Step Guide"
-description: "Comprehensive guide on integrating ReportPortal with Keycloak for SAML-based authentication, including detailed steps for Keycloak configuration and ReportPortal setup."
+title: "ReportPortal SSO with Keycloak (SAML)"
+description: "Configure ReportPortal single sign-on with Keycloak via SAML: Keycloak client setup and ReportPortal authentication configuration, step by step."
 sidebar_label: "ReportPortal Keycloak Integration"
 
 ---
@@ -13,7 +13,7 @@ sidebar_label: "ReportPortal Keycloak Integration"
   <link rel="canonical" href="https://docs.kuberocketci.io/docs/operator-guide/project-management-and-reporting/reportportal-keycloak" />
 </head>
 
-Follow the steps below to integrate the ReportPortal with Keycloak.
+Configure single sign-on for ReportPortal using Keycloak as the SAML identity provider. This guide covers creating the Keycloak SAML client and enabling the integration on the ReportPortal side.
 
 :::info
   It is also possible to install ReportPortal using the cluster add-ons. For details, please refer to the [Install via Add-Ons](../add-ons-overview.md) page.
@@ -95,3 +95,4 @@ To apply the Keycloak configuration, the Keycloak Operator is required. For inst
 
 * [Install ReportPortal](../project-management-and-reporting/install-reportportal.md)
 * [Integration With Tekton](reportportal-tekton.md)
+* [Install Keycloak](../auth/keycloak.md)

--- a/versioned_sidebars/version-3.14-sidebars.json
+++ b/versioned_sidebars/version-3.14-sidebars.json
@@ -117,6 +117,7 @@
             "operator-guide/auth/keycloak",
             "operator-guide/auth/ui-portal-oidc",
             "operator-guide/auth/configure-keycloak-oidc-eks",
+            "operator-guide/auth/eks-oidc-integration",
             "operator-guide/auth/krci-cli-client-for-keycloak",
             "operator-guide/auth/oauth2-proxy",
             "operator-guide/auth/namespace-management",


### PR DESCRIPTION


Driven by a 90-day GA4/Search Console review showing high impressions with low CTR on the Microsoft Entra SSO cluster and related pages, plus technical issues splitting ranking signals:

- Rewrite titles, meta descriptions, and answer-first openings on the Entra OIDC SSO guides, the EBS CSI driver page, the Keycloak EKS guide, ReportPortal SSO, and low-CTR blog posts to match search intent
- Add sibling interlinks across the SSO cluster, restructure the OIDC overview into a grouped hub, and add troubleshooting sections to the Argo CD and SonarQube guides
- Differentiate the orphaned EKS OIDC page from the Keycloak EKS guide and register it in the sidebar to resolve query cannibalization
- Backport all doc changes to version-3.14, the stable version serving the ranking canonical URLs, so the improvements take effect before the next release cut
- Exclude versioned/next docs from the sitemap version-agnostically (213 non-canonical URLs shipped live), remove the duplicate GTM container load, and add navbar/footer links to the marketing site
- Refresh the Entra blog post: fix redirected links, trim metadata, add freshness note and issuer guidance

