### PR TITLE
EPMDEDP-17216: docs: Bump edp-install version to 3.14.1 in install an…

### DIFF
--- a/docs/operator-guide/install-kuberocketci.md
+++ b/docs/operator-guide/install-kuberocketci.md
@@ -46,7 +46,7 @@ There are multiple ways to deploy KubeRocketCI:
     ```bash
     helm search repo epamedp/edp-install
     NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-    epamedp/edp-install     3.14.0          3.14.0           A Helm chart for KubeRocketCI Platform
+    epamedp/edp-install     3.14.1          3.14.1           A Helm chart for KubeRocketCI Platform
     ```
 
     :::note
@@ -213,11 +213,11 @@ There are multiple ways to deploy KubeRocketCI:
 
 7. Install platform in the **krci** namespace with the Helm tool:
 
-    Check the parameters in the installation chart [values.yaml](https://github.com/epam/edp-install/blob/v3.14.0/deploy-templates/values.yaml) file.
+    Check the parameters in the installation chart [values.yaml](https://github.com/epam/edp-install/blob/v3.14.1/deploy-templates/values.yaml) file.
 
     ```bash
     helm install krci epamedp/edp-install --wait --timeout=900s \
-    --version 3.14.0 \
+    --version 3.14.1 \
     --values values.yaml \
     --namespace krci \
     --create-namespace

--- a/docs/operator-guide/upgrade/upgrade-krci-3.14.md
+++ b/docs/operator-guide/upgrade/upgrade-krci-3.14.md
@@ -155,11 +155,11 @@ There are **no new breaking changes** in 3.14. Deprecations carried over from 3.
   ```yaml title="clusters/core/addons/kuberocketci/Chart.yaml"
   apiVersion: v2
   name: edp-install
-  version: 3.14.0
-  appVersion: 3.14.0
+  version: 3.14.1
+  appVersion: 3.14.1
   dependencies:
     - name: edp-install
-      version: 3.14.0
+      version: 3.14.1
       repository: https://epam.github.io/edp-helm-charts/stable
   ```
 
@@ -178,17 +178,17 @@ There are **no new breaking changes** in 3.14. Deprecations carried over from 3.
   helm repo update
 
   # Confirm the target chart version is available
-  helm search repo epamedp/edp-install --versions | grep 3.14.0
+  helm search repo epamedp/edp-install --versions | grep 3.14.1
 
   # Preview changes against your values
   helm diff upgrade <release-name> epamedp/edp-install \
-    --version 3.14.0 \
+    --version 3.14.1 \
     -f values.yaml \
     -n <namespace>
 
   # Run the upgrade
   helm upgrade --install <release-name> epamedp/edp-install \
-    --version 3.14.0 \
+    --version 3.14.1 \
     -f values.yaml \
     -n <namespace> \
     --timeout 10m \

--- a/docs/quick-start/platform-installation.md
+++ b/docs/quick-start/platform-installation.md
@@ -42,7 +42,7 @@ To deploy the platform, follow the steps below:
 2. Deploy the platform using the `helm install` command:
 
     ```bash
-    helm install krci epamedp/edp-install --version 3.14.0 --create-namespace --atomic -n krci --set global.dnsWildCard=example.com
+    helm install krci epamedp/edp-install --version 3.14.1 --create-namespace --atomic -n krci --set global.dnsWildCard=example.com
     ```
 
 3. Upon successful deployment of the KubeRocketCI Helm Chart, run the `kubectl port-forward` command:


### PR DESCRIPTION
## Description

Bump the pinned `edp-install` version from **3.14.0** to **3.14.1** across the
install-facing documentation, following the 3.14.1 patch release
(https://github.com/epam/edp-install/releases/tag/v3.14.1), which supersedes 3.14.0.

This keeps the guides pointing at the latest patch of the 3.14 minor — consistent
with the existing convention (the 3.13 upgrade guide pins `3.13.5`, not `3.13.0`).

Files updated (version pins only, no content/structure changes):
- `docs/operator-guide/upgrade/upgrade-krci-3.14.md` — Chart.yaml example + `helm search` / `helm diff` / `helm upgrade` commands
- `docs/operator-guide/install-kuberocketci.md` — `helm search` sample output, `blob/v3.14.1` values.yaml link, `helm install --version`
- `docs/quick-start/platform-installation.md` — `helm install --version`

Relates to: EPMDEDP-17216 (Align KRCI Install/Update Documentation).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement

## How Has This Been Tested?

- `npm run build` (Docusaurus production build) completes with `[SUCCESS]`, exit 0 —
  220 documents processed, 0 errors/warnings. `onBrokenLinks: 'throw'` reaching
  SUCCESS confirms all links remain valid.
- Change is version-string only (`3.14.0` → `3.14.1`); no new terms are introduced,
  so the `cspell` spell-check job is unaffected.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] Pull Request contain one commit. I squash my commits.

## Screenshots (if appropriate)

N/A — text/version-only change. Page renders under the "Next" docs version:
https://docs.kuberocketci.io/docs/next/operator-guide/upgrade/upgrade-krci-3.14

## Additional context

The `edp-cluster-add-ons` `Chart.yaml` example shown in the upgrade guide now matches
the merged add-ons bump to 3.14.1 (epam/edp-cluster-add-ons#437 follow-up).