### PR TITLE
EPMDEDP-17261: docs: align Tekton Results install guide to v0.20.0 and document DB indexes

### DIFF
--- a/cspell.config.yaml
+++ b/cspell.config.yaml
@@ -133,6 +133,7 @@ words:
   - gitfusion
   - GITFUSION
   - gitops
+  - GORM
   - godev
   - eventlistener
   - gitrevision
@@ -254,6 +255,7 @@ words:
   - Qovery
   - rabbitmq
   - rabbitmqctl
+  - recordsummary
   - regcred
   - Rego
   - rekor

--- a/docs/operator-guide/ci/tekton-long-term-storage.md
+++ b/docs/operator-guide/ci/tekton-long-term-storage.md
@@ -59,7 +59,7 @@ Tekton Results is deployed as part of the Tekton Pipelines installation. For ins
 ## Configuration
 
 :::note
-We use Postgres operator to connect to Tekton results, but you can use any other external databases supported. Please align configuration accordingly to Tekton result [documentation](https://github.com/tektoncd/results/blob/v0.19.0/docs/external-database.md).
+We use Postgres operator to connect to Tekton results, but you can use any other external databases supported. Please align configuration accordingly to Tekton result [documentation](https://github.com/tektoncd/results/blob/v0.20.0/docs/external-database.md).
 :::
 
 To configure long-term log storage for pipelines in the KubeRocketCI Portal, follow the steps below:
@@ -112,6 +112,82 @@ The retention policy agent removes only database records from PostgreSQL. It doe
 :::note
 In this example, the PGO (PostgreSQL Operator) is used for the Tekton Results database. 
 :::
+
+## Database Performance Indexes
+
+Tekton Results creates its schema through GORM auto-migration, which adds no indexes beyond the primary keys. As the
+history grows, the queries behind the KubeRocketCI Portal pipeline run history fall back to sequential scans and the
+history views become progressively slower to load. Create the indexes below to keep those queries on index scans.
+
+:::note
+`CREATE INDEX CONCURRENTLY` builds the index without locking the table for writes, so these statements are safe to run
+against a live database. They cannot run inside a transaction block, which is why each statement is applied separately.
+:::
+
+1. Find the primary PostgreSQL pod:
+
+    ```bash
+    PG_POD=$(kubectl get pods -n tekton-pipelines \
+      -l postgres-operator.crunchydata.com/cluster=results,postgres-operator.crunchydata.com/role=master \
+      -o jsonpath='{.items[0].metadata.name}')
+    ```
+
+2. Create the index covering list queries that filter by parent and type and sort by time:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_records_parent_type_created ON records (parent, type, created_time DESC);"
+    ```
+
+3. Create the index covering JSONB containment queries (`@>`) used for codebase and name filtering:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS results_annotations ON results USING GIN (annotations jsonb_path_ops);"
+    ```
+
+4. Create the index covering summary annotation filtering, which the DORA metrics views rely on:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS record_summary_annotations ON results USING GIN (recordsummary_annotations jsonb_path_ops);"
+    ```
+
+5. Verify that the indexes exist:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c "\di+"
+    ```
+
+6. Confirm that queries use them. The plan should report an `Index Scan` or `Bitmap Index Scan` on
+   `idx_records_parent_type_created` rather than a `Seq Scan`:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c "
+        EXPLAIN ANALYZE
+        SELECT * FROM records
+        WHERE parent LIKE 'tekton-pipelines/results/%'
+          AND type = 'tekton.dev/v1.PipelineRun'
+        ORDER BY created_time DESC
+        LIMIT 10;
+      "
+    ```
+
+To remove the indexes, drop them by name:
+
+```bash
+kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+  psql -U postgres -d results -c "
+    DROP INDEX IF EXISTS idx_records_parent_type_created;
+    DROP INDEX IF EXISTS results_annotations;
+    DROP INDEX IF EXISTS record_summary_annotations;
+  "
+```
 
 ## Related Articles
 

--- a/docs/operator-guide/install-tekton.md
+++ b/docs/operator-guide/install-tekton.md
@@ -70,11 +70,30 @@ To install Tekton resources, follow the steps below:
     kubectl apply -f https://infra.tekton.dev/tekton-releases/chains/previous/v0.28.1/release.yaml
     ```
 
-5. Install Tekton Results v0.19.0 using the release file:
+5. Install Tekton Results v0.20.0 using the KubeRocketCI manifest:
+
+    :::warning
+      Unlike the components above, Tekton Results **must not** be installed from the plain upstream release file.
+      The Platform customizes it, and the upstream `release.yaml` bundles its own PostgreSQL instance that conflicts
+      with the Platform database. Use the [results.yaml](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/tekton/results.yaml)
+      manifest from the [edp-cluster-add-ons](https://github.com/epam/edp-cluster-add-ons) repository instead.
+    :::
 
     ```bash
-    kubectl apply -f https://infra.tekton.dev/tekton-releases/results/previous/v0.19.0/release.yaml
+    kubectl apply -f https://raw.githubusercontent.com/epam/edp-cluster-add-ons/main/clusters/core/addons/tekton/results.yaml
     ```
+
+    The manifest is based on the upstream `release_base.yaml` (the variant without a bundled database) and adds the
+    following Platform customizations:
+
+    - **External database.** Connection settings point to the PostgreSQL cluster defined in
+      [results-pg.yaml](https://github.com/epam/edp-cluster-add-ons/blob/main/clusters/core/addons/tekton/results-pg.yaml),
+      which must be deployed first. See [Tekton Long-Term Storage](./ci/tekton-long-term-storage.md) for details.
+    - **Summary labels.** The watcher runs with `-summary_labels`, which records the codebase, branch, pipeline type,
+      and CD pipeline labels on archived runs. The KubeRocketCI Portal relies on these to render the pipeline run
+      history, so omitting the flag leaves history entries without their metadata.
+    - **Log storage.** The Results API serves pipeline logs from a persistent volume, and a CronJob prunes entries
+      older than 30 days.
 
 ## Installation on OKD cluster
 

--- a/versioned_docs/version-3.13/operator-guide/ci/tekton-long-term-storage.md
+++ b/versioned_docs/version-3.13/operator-guide/ci/tekton-long-term-storage.md
@@ -113,6 +113,82 @@ The retention policy agent removes only database records from PostgreSQL. It doe
 In this example, the PGO (PostgreSQL Operator) is used for the Tekton Results database. 
 :::
 
+## Database Performance Indexes
+
+Tekton Results creates its schema through GORM auto-migration, which adds no indexes beyond the primary keys. As the
+history grows, the queries behind the KubeRocketCI Portal pipeline run history fall back to sequential scans and the
+history views become progressively slower to load. Create the indexes below to keep those queries on index scans.
+
+:::note
+`CREATE INDEX CONCURRENTLY` builds the index without locking the table for writes, so these statements are safe to run
+against a live database. They cannot run inside a transaction block, which is why each statement is applied separately.
+:::
+
+1. Find the primary PostgreSQL pod:
+
+    ```bash
+    PG_POD=$(kubectl get pods -n tekton-pipelines \
+      -l postgres-operator.crunchydata.com/cluster=results,postgres-operator.crunchydata.com/role=master \
+      -o jsonpath='{.items[0].metadata.name}')
+    ```
+
+2. Create the index covering list queries that filter by parent and type and sort by time:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_records_parent_type_created ON records (parent, type, created_time DESC);"
+    ```
+
+3. Create the index covering JSONB containment queries (`@>`) used for codebase and name filtering:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS results_annotations ON results USING GIN (annotations jsonb_path_ops);"
+    ```
+
+4. Create the index covering summary annotation filtering, which the DORA metrics views rely on:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS record_summary_annotations ON results USING GIN (recordsummary_annotations jsonb_path_ops);"
+    ```
+
+5. Verify that the indexes exist:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c "\di+"
+    ```
+
+6. Confirm that queries use them. The plan should report an `Index Scan` or `Bitmap Index Scan` on
+   `idx_records_parent_type_created` rather than a `Seq Scan`:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c "
+        EXPLAIN ANALYZE
+        SELECT * FROM records
+        WHERE parent LIKE 'tekton-pipelines/results/%'
+          AND type = 'tekton.dev/v1.PipelineRun'
+        ORDER BY created_time DESC
+        LIMIT 10;
+      "
+    ```
+
+To remove the indexes, drop them by name:
+
+```bash
+kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+  psql -U postgres -d results -c "
+    DROP INDEX IF EXISTS idx_records_parent_type_created;
+    DROP INDEX IF EXISTS results_annotations;
+    DROP INDEX IF EXISTS record_summary_annotations;
+  "
+```
+
 ## Related Articles
 
 * [Add Application](../../user-guide/add-application.md)

--- a/versioned_docs/version-3.14/operator-guide/ci/tekton-long-term-storage.md
+++ b/versioned_docs/version-3.14/operator-guide/ci/tekton-long-term-storage.md
@@ -113,6 +113,82 @@ The retention policy agent removes only database records from PostgreSQL. It doe
 In this example, the PGO (PostgreSQL Operator) is used for the Tekton Results database. 
 :::
 
+## Database Performance Indexes
+
+Tekton Results creates its schema through GORM auto-migration, which adds no indexes beyond the primary keys. As the
+history grows, the queries behind the KubeRocketCI Portal pipeline run history fall back to sequential scans and the
+history views become progressively slower to load. Create the indexes below to keep those queries on index scans.
+
+:::note
+`CREATE INDEX CONCURRENTLY` builds the index without locking the table for writes, so these statements are safe to run
+against a live database. They cannot run inside a transaction block, which is why each statement is applied separately.
+:::
+
+1. Find the primary PostgreSQL pod:
+
+    ```bash
+    PG_POD=$(kubectl get pods -n tekton-pipelines \
+      -l postgres-operator.crunchydata.com/cluster=results,postgres-operator.crunchydata.com/role=master \
+      -o jsonpath='{.items[0].metadata.name}')
+    ```
+
+2. Create the index covering list queries that filter by parent and type and sort by time:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_records_parent_type_created ON records (parent, type, created_time DESC);"
+    ```
+
+3. Create the index covering JSONB containment queries (`@>`) used for codebase and name filtering:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS results_annotations ON results USING GIN (annotations jsonb_path_ops);"
+    ```
+
+4. Create the index covering summary annotation filtering, which the DORA metrics views rely on:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c \
+      "CREATE INDEX CONCURRENTLY IF NOT EXISTS record_summary_annotations ON results USING GIN (recordsummary_annotations jsonb_path_ops);"
+    ```
+
+5. Verify that the indexes exist:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c "\di+"
+    ```
+
+6. Confirm that queries use them. The plan should report an `Index Scan` or `Bitmap Index Scan` on
+   `idx_records_parent_type_created` rather than a `Seq Scan`:
+
+    ```bash
+    kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+      psql -U postgres -d results -c "
+        EXPLAIN ANALYZE
+        SELECT * FROM records
+        WHERE parent LIKE 'tekton-pipelines/results/%'
+          AND type = 'tekton.dev/v1.PipelineRun'
+        ORDER BY created_time DESC
+        LIMIT 10;
+      "
+    ```
+
+To remove the indexes, drop them by name:
+
+```bash
+kubectl exec -it -n tekton-pipelines "$PG_POD" -c database -- \
+  psql -U postgres -d results -c "
+    DROP INDEX IF EXISTS idx_records_parent_type_created;
+    DROP INDEX IF EXISTS results_annotations;
+    DROP INDEX IF EXISTS record_summary_annotations;
+  "
+```
+
 ## Related Articles
 
 * [Add Application](../../user-guide/add-application.md)


### PR DESCRIPTION


Tekton Results is the one Tekton component the Platform meaningfully customizes, but the install guide pointed at the plain upstream release file. That file bundles its own PostgreSQL instance, which conflicts with the Platform database, and omits the watcher summary_labels flag the Portal relies on to render pipeline run history metadata. Point the step at the edp-cluster-add-ons manifest instead and describe the customizations it carries: external database, summary labels, and log storage. The remaining Tekton components are deployed unmodified, so their upstream install steps are left alone.

Bump the referenced Results version to v0.20.0, which carries the upstream watcher fix that populates RecordSummary start and end times.

Document the PostgreSQL performance indexes that the results database requires. Tekton Results builds its schema through GORM auto-migration and creates no indexes beyond the primary keys, so the queries behind the Portal history views degrade to sequential scans as history accumulates. The indexes are already applied in production; this records how to create, verify, and roll them back.

Add the same index section to the 3.13 and 3.14 versioned guides, which describe the same PostgreSQL-backed storage. 3.12 is excluded because it documents the earlier OpenSearch architecture with no results database.

