### PR TITLE
EPMDEDP-17274: docs: Align the installation guides with the 3.15.0 release

### DIFF
--- a/docs/operator-guide/install-kuberocketci.md
+++ b/docs/operator-guide/install-kuberocketci.md
@@ -46,7 +46,7 @@ There are multiple ways to deploy KubeRocketCI:
     ```bash
     helm search repo epamedp/edp-install
     NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-    epamedp/edp-install     3.14.1          3.14.1           A Helm chart for KubeRocketCI Platform
+    epamedp/edp-install     3.15.0          3.15.0           A Helm chart for KubeRocketCI Platform
     ```
 
     :::note
@@ -213,11 +213,11 @@ There are multiple ways to deploy KubeRocketCI:
 
 7. Install platform in the **krci** namespace with the Helm tool:
 
-    Check the parameters in the installation chart [values.yaml](https://github.com/epam/edp-install/blob/v3.14.1/deploy-templates/values.yaml) file.
+    Check the parameters in the installation chart [values.yaml](https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml) file.
 
     ```bash
     helm install krci epamedp/edp-install --wait --timeout=900s \
-    --version 3.14.1 \
+    --version 3.15.0 \
     --values values.yaml \
     --namespace krci \
     --create-namespace

--- a/docs/operator-guide/kubernetes-cluster-scaling/namespace-and-cluster-autoscaling.md
+++ b/docs/operator-guide/kubernetes-cluster-scaling/namespace-and-cluster-autoscaling.md
@@ -209,7 +209,7 @@ You can install and configure KEDA-tenant either using the [add-ons approach](ht
 
   - **`namespaces`** – List of namespaces where the KRCI platform is installed.
   - **`timeInterval`** – Idle time after which the platform will automatically scale down to **0 replicas**.
-  - **`gitProviders`** – List of Git providers configured to work with the platform (this list must match the configuration set during the installation of the [`edp-install`](https://github.com/epam/edp-install/blob/release/3.11/deploy-templates/values.yaml#L32) Helm chart).
+  - **`gitProviders`** – List of Git providers configured to work with the platform (this list must match the configuration set during the installation of the [`edp-install`](https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml#L35) Helm chart).
 
   Below are the key parameters for configuring the KEDA Tenants Helm chart:
 

--- a/docs/operator-guide/troubleshooting/environment-creation.md
+++ b/docs/operator-guide/troubleshooting/environment-creation.md
@@ -21,7 +21,7 @@ Failed to create an environment due to the following error:
 
 ## Cause
 
-KubeRocketCI offers several approaches for namespace management: namespaces can be created by users, by KubeRocketCI itself, or by Argo CD. If you expect KubeRocketCI to handle namespace creation, ensure that the [cd-pipeline-operator](https://github.com/epam/edp-cd-pipeline-operator), a component of KubeRocketCI, has the necessary permissions. This permission is managed by the `manageNamespace` parameter of the [values.yaml](https://github.com/epam/edp-install/blob/v3.14.0/deploy-templates/values.yaml#L288) file.
+KubeRocketCI offers several approaches for namespace management: namespaces can be created by users, by KubeRocketCI itself, or by Argo CD. If you expect KubeRocketCI to handle namespace creation, ensure that the [cd-pipeline-operator](https://github.com/epam/edp-cd-pipeline-operator), a component of KubeRocketCI, has the necessary permissions. This permission is managed by the `manageNamespace` parameter of the [values.yaml](https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml#L288) file.
 
 If the `manageNamespace` parameter is set to false, it means the KubeRocketCI does not have permission to create namespaces and the procedure of creating namespaces in your project is delegated to a concrete person.
 

--- a/docs/quick-start/platform-installation.md
+++ b/docs/quick-start/platform-installation.md
@@ -42,7 +42,7 @@ To deploy the platform, follow the steps below:
 2. Deploy the platform using the `helm install` command:
 
     ```bash
-    helm install krci epamedp/edp-install --version 3.14.1 --create-namespace --atomic -n krci --set global.dnsWildCard=example.com
+    helm install krci epamedp/edp-install --version 3.15.0 --create-namespace --atomic -n krci --set global.dnsWildCard=example.com
     ```
 
 3. Upon successful deployment of the KubeRocketCI Helm Chart, run the `kubectl port-forward` command:

--- a/versioned_docs/version-3.15/operator-guide/install-kuberocketci.md
+++ b/versioned_docs/version-3.15/operator-guide/install-kuberocketci.md
@@ -46,7 +46,7 @@ There are multiple ways to deploy KubeRocketCI:
     ```bash
     helm search repo epamedp/edp-install
     NAME                    CHART VERSION   APP VERSION     DESCRIPTION
-    epamedp/edp-install     3.14.1          3.14.1           A Helm chart for KubeRocketCI Platform
+    epamedp/edp-install     3.15.0          3.15.0           A Helm chart for KubeRocketCI Platform
     ```
 
     :::note
@@ -213,11 +213,11 @@ There are multiple ways to deploy KubeRocketCI:
 
 7. Install platform in the **krci** namespace with the Helm tool:
 
-    Check the parameters in the installation chart [values.yaml](https://github.com/epam/edp-install/blob/v3.14.1/deploy-templates/values.yaml) file.
+    Check the parameters in the installation chart [values.yaml](https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml) file.
 
     ```bash
     helm install krci epamedp/edp-install --wait --timeout=900s \
-    --version 3.14.1 \
+    --version 3.15.0 \
     --values values.yaml \
     --namespace krci \
     --create-namespace

--- a/versioned_docs/version-3.15/operator-guide/kubernetes-cluster-scaling/namespace-and-cluster-autoscaling.md
+++ b/versioned_docs/version-3.15/operator-guide/kubernetes-cluster-scaling/namespace-and-cluster-autoscaling.md
@@ -209,7 +209,7 @@ You can install and configure KEDA-tenant either using the [add-ons approach](ht
 
   - **`namespaces`** – List of namespaces where the KRCI platform is installed.
   - **`timeInterval`** – Idle time after which the platform will automatically scale down to **0 replicas**.
-  - **`gitProviders`** – List of Git providers configured to work with the platform (this list must match the configuration set during the installation of the [`edp-install`](https://github.com/epam/edp-install/blob/release/3.11/deploy-templates/values.yaml#L32) Helm chart).
+  - **`gitProviders`** – List of Git providers configured to work with the platform (this list must match the configuration set during the installation of the [`edp-install`](https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml#L35) Helm chart).
 
   Below are the key parameters for configuring the KEDA Tenants Helm chart:
 

--- a/versioned_docs/version-3.15/operator-guide/troubleshooting/environment-creation.md
+++ b/versioned_docs/version-3.15/operator-guide/troubleshooting/environment-creation.md
@@ -21,7 +21,7 @@ Failed to create an environment due to the following error:
 
 ## Cause
 
-KubeRocketCI offers several approaches for namespace management: namespaces can be created by users, by KubeRocketCI itself, or by Argo CD. If you expect KubeRocketCI to handle namespace creation, ensure that the [cd-pipeline-operator](https://github.com/epam/edp-cd-pipeline-operator), a component of KubeRocketCI, has the necessary permissions. This permission is managed by the `manageNamespace` parameter of the [values.yaml](https://github.com/epam/edp-install/blob/v3.14.0/deploy-templates/values.yaml#L288) file.
+KubeRocketCI offers several approaches for namespace management: namespaces can be created by users, by KubeRocketCI itself, or by Argo CD. If you expect KubeRocketCI to handle namespace creation, ensure that the [cd-pipeline-operator](https://github.com/epam/edp-cd-pipeline-operator), a component of KubeRocketCI, has the necessary permissions. This permission is managed by the `manageNamespace` parameter of the [values.yaml](https://github.com/epam/edp-install/blob/v3.15.0/deploy-templates/values.yaml#L288) file.
 
 If the `manageNamespace` parameter is set to false, it means the KubeRocketCI does not have permission to create namespaces and the procedure of creating namespaces in your project is delegated to a concrete person.
 

--- a/versioned_docs/version-3.15/quick-start/platform-installation.md
+++ b/versioned_docs/version-3.15/quick-start/platform-installation.md
@@ -42,7 +42,7 @@ To deploy the platform, follow the steps below:
 2. Deploy the platform using the `helm install` command:
 
     ```bash
-    helm install krci epamedp/edp-install --version 3.14.1 --create-namespace --atomic -n krci --set global.dnsWildCard=example.com
+    helm install krci epamedp/edp-install --version 3.15.0 --create-namespace --atomic -n krci --set global.dnsWildCard=example.com
     ```
 
 3. Upon successful deployment of the KubeRocketCI Helm Chart, run the `kubectl port-forward` command:


### PR DESCRIPTION


The install and quick-start guides still pinned edp-install 3.14.1, so anyone following them after the 3.15.0 release installed the previous version.

Bump the chart version in the helm search sample output, the helm install command and the quick-start one-liner, and repoint the values.yaml reference link at the v3.15.0 tag.

Two further values.yaml deep links were stale and carried line anchors that had drifted: the autoscaling guide pointed at release/3.11 (#L32 for gitProviders, now line 35) and the environment-creation troubleshooting page at v3.14.0. Both now target v3.15.0 with anchors verified against the tagged file.

No new configuration is required for a fresh 3.15.0 install - the hardened ServiceAccount, SSH known-hosts and TLS defaults apply automatically, so the guides need version bumps only; the migration steps live in the 3.15 upgrade guide.

Applied to both docs/ and versioned_docs/version-3.15/, since 3.15 is the default version served at /docs and docs/ only serves /next/.

Verified with a full production build (onBrokenLinks: throw) and cspell.

