### PR TITLE
EPMDEDP-17274: docs: Align site tagline and homepage messaging with AI-fabric positioning

### DIFF
--- a/docs/about-platform.md
+++ b/docs/about-platform.md
@@ -15,6 +15,8 @@ sidebar_label: "About KubeRocketCI"
 
 KubeRocketCI, which is also called **"The Rocket"**, is a platform that allows shortening the time that is passed before an active development can start from several months to several hours.
 
+The same pipelines, quality gates, and RBAC guardrails serve both your engineers and AI coding agents. On top of this well-defined baseline, KubeRocketCI equips agents with the skills and tools they need, so their effort goes into business features rather than delivery plumbing. Every change — human- or agent-authored — follows one golden path through validation to production.
+
 The platform consists of the following blocks:
 
 - The platform is based on managed infrastructure and container orchestration

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -11,7 +11,7 @@ const siteStructuredData = {
       url: 'https://docs.kuberocketci.io',
       name: 'KubeRocketCI Documentation',
       description:
-        'Explore KubeRocketCI Documentation for detailed guides, tutorials, and insights into KubeRocketCI CI/CD flow, platform components, and add-ons. Learn how to enhance your DevOps practices with KubeRocketCI.',
+        'KubeRocketCI documentation — guides, tutorials, and references for the open-source CI/CD platform on Kubernetes, serving engineers and their AI agents.',
       sameAs: [
         'https://medium.com/kuberocketci',
         'https://hub.docker.com/u/epamedp',
@@ -53,7 +53,7 @@ const siteStructuredData = {
 
 const config: Config = {
   title: 'KubeRocketCI',
-  tagline: 'Build Your Delivery Rocket',
+  tagline: 'The harness for your AI fabric',
   favicon: 'img/favicon.ico',
 
   // Set the production url of your site here
@@ -265,7 +265,7 @@ const config: Config = {
         addMdExtension: false,
         title: 'KubeRocketCI Documentation',
         description:
-          'Explore KubeRocketCI Documentation for CI/CD, operator and user guides, quick start, and API. Learn how to enhance your DevOps practices with KubeRocketCI.',
+          'KubeRocketCI documentation for CI/CD on Kubernetes — quick start, operator, user, and developer guides. Delivery infrastructure for engineers and AI agents.',
         includeBlog: true,
         ignoreFiles: ['faq/**', 'api/**'], // api/ — custom CRs for operators, they bloat llms-full.txt
         excludeImports: true,
@@ -279,7 +279,7 @@ const config: Config = {
       {
         name: 'keywords',
         content:
-          'KubeRocketCI, CI/CD, DevOps, Kubernetes, Tekton, Helm Charts, AWS, Argo CD, Add-Ons, Installation Guide, User Guide, Developer Guide, Operator Guide',
+          'KubeRocketCI, CI/CD, DevOps, Kubernetes, Tekton, Helm Charts, AWS, Argo CD, Add-Ons, Installation Guide, User Guide, Developer Guide, Operator Guide, AI Agents, Agentic AI, Quality Gates, Golden Path, Ephemeral Environments',
       },
       { name: 'author', content: 'KubeRocketCI Team' },
       // Open Graph (use `property=` per the OG spec). Per-page `og:title`,
@@ -295,7 +295,7 @@ const config: Config = {
       { name: 'twitter:image', content: 'https://docs.kuberocketci.io/img/kuberocketci-social-card.jpg' },
     ],
     description:
-      'KubeRocketCI is an open-source CI/CD platform for Kubernetes teams. It gives you a full delivery pipeline — from code commit to live deploy. Get Tekton builds, Argo CD GitOps, and security scans ready to use out of the box.',
+      'Open-source CI/CD platform for Kubernetes — delivery infrastructure for engineers and their AI agents. Tekton, Argo CD GitOps, and quality gates out of the box.',
     videoTeaser: 'https://www.youtube.com/watch?v=wiAaAHu17mw',
     mailTo: 'mailto:SupportEPMD-EDP@epam.com?subject=KubeRocketCI Demo Request',
     announcementBar: {

--- a/src/features/home/components/Features/index.tsx
+++ b/src/features/home/components/Features/index.tsx
@@ -13,7 +13,8 @@ export const Features = () => {
           Platform Capabilities
         </Heading>
         <p className={styles.sectionSubheading}>
-          Everything you need to ship on Kubernetes — from first commit to production, with security built in.
+          Everything you need to ship on Kubernetes — from first commit to production, with security built in,
+          whether the commit comes from an engineer or an AI agent.
         </p>
 
         <div className={styles.bento}>

--- a/src/features/home/components/Hero/index.tsx
+++ b/src/features/home/components/Hero/index.tsx
@@ -64,11 +64,11 @@ export const Hero = () => {
               <p className={styles.heroBannerSubtitle}>{siteConfig.tagline}</p>
             </div>
             <p className={styles.heroBannerDescription}>
-              KubeRocketCI is an open-source CI/CD platform for Kubernetes teams.
-              It gives you a full delivery pipeline — from code commit to live deploy.
+              KubeRocketCI is an open-source CI/CD platform for Kubernetes teams —
+              delivery infrastructure for your engineers and their AI agents, from code commit to live deploy.
             </p>
             <p className={styles.heroBannerDescription}>
-              Get Tekton builds, Argo CD GitOps, and security scans ready to use.
+              Get Tekton builds, Argo CD GitOps, quality gates, and security scans ready to use.
               Browse the Quick&nbsp;Start guide or dive into the Operator and User guides.
             </p>
           </div>

--- a/src/features/home/index.tsx
+++ b/src/features/home/index.tsx
@@ -7,8 +7,8 @@ import { RecentBlogPosts } from './components/RecentBlogPosts';
 export const Home = () => {
   return (
     <Layout
-      title="Cloud-Native CI/CD on Kubernetes"
-      description="Documentation for KubeRocketCI — an open-source CI/CD platform on Kubernetes. Quick-start, operator and user guides, and references for Tekton, Argo CD and DevSecOps."
+      title="Cloud-Native CI/CD for Engineers and AI Agents"
+      description="Documentation for KubeRocketCI — CI/CD on Kubernetes for engineers and AI agents. Quick-start, operator and user guides, Tekton, Argo CD and DevSecOps."
     >
       <Hero />
       <GetStarted />


### PR DESCRIPTION


- Replace the site tagline and extend hero, features, and about-platform copy with the engineers-and-AI-agents framing and skills/tools baseline
- Refresh meta descriptions, JSON-LD, llms.txt description, and keywords within SEO length gates for the new positioning

#